### PR TITLE
Define WCharacter functions as macros instead of inline functions.

### DIFF
--- a/api/WCharacter.h
+++ b/api/WCharacter.h
@@ -17,152 +17,25 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef Character_h
-#define Character_h
+#pragma once
 
 #include <ctype.h>
 
 // WCharacter.h prototypes
-inline bool isAlphaNumeric(int c) __attribute__((always_inline));
-inline bool isAlpha(int c) __attribute__((always_inline));
-inline bool isAscii(int c) __attribute__((always_inline));
-inline bool isWhitespace(int c) __attribute__((always_inline));
-inline bool isControl(int c) __attribute__((always_inline));
-inline bool isDigit(int c) __attribute__((always_inline));
-inline bool isGraph(int c) __attribute__((always_inline));
-inline bool isLowerCase(int c) __attribute__((always_inline));
-inline bool isPrintable(int c) __attribute__((always_inline));
-inline bool isPunct(int c) __attribute__((always_inline));
-inline bool isSpace(int c) __attribute__((always_inline));
-inline bool isUpperCase(int c) __attribute__((always_inline));
-inline bool isHexadecimalDigit(int c) __attribute__((always_inline));
-inline int toAscii(int c) __attribute__((always_inline));
-inline int toLowerCase(int c) __attribute__((always_inline));
-inline int toUpperCase(int c)__attribute__((always_inline));
+#define isAlphaNumeric(c)       (isalnum(c) ? true : false)
+#define isAlpha(c)              (isalpha(c) ? true : false)
+#define isAscii(c)              (isascii(c) ? true : false)
+#define isWhitespace(c)         (isblank(c) ? true : false)
+#define isControl(c)            (iscntrl(c) ? true : false)
+#define isDigit(c)              (isdigit(c) ? true : false)
+#define isGraph(c)              (isgraph(c) ? true : false)
+#define isLowerCase(c)          (islower(c) ? true : false)
+#define isPrintable(c)          (isprint(c) ? true : false)
+#define isPunct(c)              (ispunct(c) ? true : false)
+#define isSpace(c)              (isspace(c) ? true : false)
+#define isUpperCase(c)          (isupper(c) ? true : false)
+#define isHexadecimalDigit(c)   (isxdigit(c) ? true : false)
 
-
-// Checks for an alphanumeric character. 
-// It is equivalent to (isalpha(c) || isdigit(c)).
-inline bool isAlphaNumeric(int c) 
-{
-  return ( isalnum(c) == 0 ? false : true);
-}
-
-
-// Checks for an alphabetic character. 
-// It is equivalent to (isupper(c) || islower(c)).
-inline bool isAlpha(int c)
-{
-  return ( isalpha(c) == 0 ? false : true);
-}
-
-
-// Checks whether c is a 7-bit unsigned char value 
-// that fits into the ASCII character set.
-inline bool isAscii(int c)
-{
-  return ( isascii (c) == 0 ? false : true);
-}
-
-
-// Checks for a blank character, that is, a space or a tab.
-inline bool isWhitespace(int c)
-{
-  return ( isblank (c) == 0 ? false : true);
-}
-
-
-// Checks for a control character.
-inline bool isControl(int c)
-{
-  return ( iscntrl (c) == 0 ? false : true);
-}
-
-
-// Checks for a digit (0 through 9).
-inline bool isDigit(int c)
-{
-  return ( isdigit (c) == 0 ? false : true);
-}
-
-
-// Checks for any printable character except space.
-inline bool isGraph(int c)
-{
-  return ( isgraph (c) == 0 ? false : true);
-}
-
-
-// Checks for a lower-case character.
-inline bool isLowerCase(int c)
-{
-  return (islower (c) == 0 ? false : true);
-}
-
-
-// Checks for any printable character including space.
-inline bool isPrintable(int c)
-{
-  return ( isprint (c) == 0 ? false : true);
-}
-
-
-// Checks for any printable character which is not a space 
-// or an alphanumeric character.
-inline bool isPunct(int c)
-{
-  return ( ispunct (c) == 0 ? false : true);
-}
-
-
-// Checks for white-space characters. For the avr-libc library, 
-// these are: space, formfeed ('\f'), newline ('\n'), carriage 
-// return ('\r'), horizontal tab ('\t'), and vertical tab ('\v').
-inline bool isSpace(int c)
-{
-  return ( isspace (c) == 0 ? false : true);
-}
-
-
-// Checks for an uppercase letter.
-inline bool isUpperCase(int c)
-{
-  return ( isupper (c) == 0 ? false : true);
-}
-
-
-// Checks for a hexadecimal digits, i.e. one of 0 1 2 3 4 5 6 7 
-// 8 9 a b c d e f A B C D E F.
-inline bool isHexadecimalDigit(int c)
-{
-  return ( isxdigit (c) == 0 ? false : true);
-}
-
-
-// Converts c to a 7-bit unsigned char value that fits into the 
-// ASCII character set, by clearing the high-order bits.
-inline int toAscii(int c)
-{
-  return toascii (c);
-}
-
-
-// Warning:
-// Many people will be unhappy if you use this function. 
-// This function will convert accented letters into random 
-// characters.
-
-// Converts the letter c to lower case, if possible.
-inline int toLowerCase(int c)
-{
-  return tolower (c);
-}
-
-
-// Converts the letter c to upper case, if possible.
-inline int toUpperCase(int c)
-{
-  return toupper (c);
-}
-
-#endif
+#define toAscii(c)              (toascii(c))
+#define toLowerCase(c)          (tolower(c))
+#define toUpperCase(c)          (toupper(c))


### PR DESCRIPTION
Define functions in WCharacter.h as macros instead of inline functions.  Macros should be functionally equivalent and more portable than using `__attribute__((always_inline))`.

Technically, we could also just cast the result to `bool` and eliminate the explicit test and return of `true` or `false` values.  However, I think leaving the explicit test is safer as it is guaranteed to return consistent `bool` results, regardless of implementation of underlying functions in <ctype.h>.  Returning consistent `bool` values will protect against users that misuse `bool` tests by doing comparisons against `true` or `false`.