### PR TITLE
Swap definitions of isWhitespace and isSpace

### DIFF
--- a/api/WCharacter.h
+++ b/api/WCharacter.h
@@ -65,10 +65,12 @@ inline bool isAscii(int c)
 }
 
 
-// Checks for a blank character, that is, a space or a tab.
+// Checks for white-space characters. For the avr-libc library,
+// these are: space, formfeed ('\f'), newline ('\n'), carriage
+// return ('\r'), horizontal tab ('\t'), and vertical tab ('\v').
 inline bool isWhitespace(int c)
 {
-  return ( isblank (c) == 0 ? false : true);
+  return ( isspace (c) == 0 ? false : true);
 }
 
 
@@ -115,12 +117,10 @@ inline bool isPunct(int c)
 }
 
 
-// Checks for white-space characters. For the avr-libc library, 
-// these are: space, formfeed ('\f'), newline ('\n'), carriage 
-// return ('\r'), horizontal tab ('\t'), and vertical tab ('\v').
+// Checks for a blank character, that is, a space or a tab.
 inline bool isSpace(int c)
 {
-  return ( isspace (c) == 0 ? false : true);
+  return ( isblank (c) == 0 ? false : true);
 }
 
 


### PR DESCRIPTION
Previously, the behavior of `isWhitespace` did not match what was stated in the [documentation](https://www.arduino.cc/reference/en/language/functions/characters/iswhitespace/):

>Analyse if a char is a white space, that is space, formfeed ('\f'), newline ('\n'), carriage return ('\r'), horizontal tab ('\t'), and vertical tab ('\v')). Returns true if thisChar contains a white space.

Previously, the behavior of `isSpace` did not match what was stated in the [documentation](https://www.arduino.cc/reference/en/language/functions/characters/isspace/):

>Analyse if a char is the space character. Returns true if thisChar contains the space character.

A strict reading of the documentation for `isSpace` would indicate that it should only match on ASCII value 32 (true space). The change made here will cause it to match only a true space or a tab.

---
I realize this is a breaking change. It is the action recommended in the issue report:
https://github.com/arduino/Arduino/issues/7041#issuecomment-353302786

The alternative is to leave the code as-is and correct the documentation, which I am happy to do if the decision goes that way.

There is also the question of how `isSpace` should work. I can make it match on space, and not on tab if that's preferable. If left as it currently is in this PR, the documentation will need to be updated (once the updated code has been released) to indicate that it also matches on tab.

I'm submitting the PR to this repo as it seems that ArduinoCore-API should now act as the model for the non-architecture specific code in other cores until the time comes for them to transition to using ArduinoCore-API directly. If accepted here, I can submit the equivalent pull requests to the other core repositories.

---
Fixes https://github.com/arduino/Arduino/issues/7041

Reference: http://forum.arduino.cc/index.php?topic=597290

---
Demonstration sketch:
```c++
void setup() {
  Serial.begin(9600);
  while (!Serial) {}
  const char chars[] = {'\f', '\n', '\r', '\v', '\t', ' ', 'a'};
  for (byte charCounter = 0; charCounter < sizeof(chars); charCounter++) {
    Serial.print("isWhitespace(");
    Serial.print((byte)chars[charCounter]);
    Serial.print(") == ");
    Serial.println(isWhitespace(chars[charCounter]) ? "true" : "false");
    Serial.print("isSpace(");
    Serial.print((byte)chars[charCounter]);
    Serial.print(") == ");
    Serial.println(isSpace(chars[charCounter]) ? "true" : "false");
  }
}

void loop() {}
```