### PR TITLE
Enabling printf style output method with variadic arguments

### DIFF
--- a/api/Print.cpp
+++ b/api/Print.cpp
@@ -144,6 +144,15 @@ size_t Print::print(const Printable& x)
   return x.printTo(*this);
 }
 
+size_t Print::printf(char const * fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  size_t const n = vprintf(fmt, args);
+  va_end(args);
+  return n;
+}
+
 size_t Print::println(void)
 {
   return write("\r\n");
@@ -229,6 +238,16 @@ size_t Print::println(double num, int digits)
 size_t Print::println(const Printable& x)
 {
   size_t n = print(x);
+  n += println();
+  return n;
+}
+
+size_t Print::printfln(char const * fmt, ...)
+{
+  va_list args;
+  va_start(args, fmt);
+  size_t n = vprintf(fmt, args);
+  va_end(args);
   n += println();
   return n;
 }
@@ -373,4 +392,14 @@ size_t Print::printFloat(double number, uint8_t digits)
   }
 
   return n;
+}
+
+size_t Print::vprintf(char const * fmt, va_list args)
+{
+  static size_t const MSG_BUF_SIZE = 64;
+  char msg_buf[MSG_BUF_SIZE] = {0};
+
+  int const length = vsnprintf(msg_buf, MSG_BUF_SIZE, fmt, args);
+
+  return write(msg_buf, length);
 }

--- a/api/Print.h
+++ b/api/Print.h
@@ -36,6 +36,7 @@ class Print
     size_t printNumber(unsigned long, uint8_t);
     size_t printULLNumber(unsigned long long, uint8_t);
     size_t printFloat(double, uint8_t);
+    size_t vprintf(char const * fmt, va_list args);
   protected:
     void setWriteError(int err = 1) { write_error = err; }
   public:
@@ -67,6 +68,7 @@ class Print
     size_t print(unsigned long long, int = DEC);
     size_t print(double, int = 2);
     size_t print(const Printable&);
+    size_t printf(char const * fmt, ...);
 
     size_t println(const __FlashStringHelper *);
     size_t println(const String &s);
@@ -82,5 +84,6 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+    size_t printfln(char const * fmt, ...);
 };
 


### PR DESCRIPTION
Usage example:
```C++
void setup() {
  Serial.begin(9600);
}

static int loop_cnt = 0;

void loop() {
  Serial.printf  ("[%d] ", millis()); 
  Serial.printfln("Loop Cnt %d", loop_cnt);
  loop_cnt++;
  delay(1000);  
}
```
Output:
```
[0] Loop Cnt 0
[999] Loop Cnt 1
[199] Loop Cnt 2
...
```
The function can't be named `print` because in this case its signature overlaps with `size_t print(const char[])` (No variadic arguments is a legimitate use case).