### PR TITLE
 Strings without null-termination

### DIFF
--- a/api/String.cpp
+++ b/api/String.cpp
@@ -199,6 +199,7 @@ String & String::copy(const char *cstr, unsigned int length)
 	}
 	len = length;
 	memcpy(buffer, cstr, length);
+	buffer[len] = '\0';
 	return *this;
 }
 
@@ -220,6 +221,7 @@ void String::move(String &rhs)
 		if (rhs && capacity >= rhs.len) {
 			memcpy(buffer, rhs.buffer, rhs.len);
 			len = rhs.len;
+			buffer[len] = '\0';
 			rhs.len = 0;
 			return;
 		} else {
@@ -292,6 +294,7 @@ unsigned char String::concat(const char *cstr, unsigned int length)
 	if (!reserve(newlen)) return 0;
 	memcpy(buffer + len, cstr, length);
 	len = newlen;
+	buffer[len] = '\0';
 	return 1;
 }
 

--- a/api/String.cpp
+++ b/api/String.cpp
@@ -297,10 +297,7 @@ unsigned char String::concat(const char *cstr)
 
 unsigned char String::concat(char c)
 {
-	char buf[2];
-	buf[0] = c;
-	buf[1] = 0;
-	return concat(buf, 1);
+	return concat(&c, 1);
 }
 
 unsigned char String::concat(unsigned char num)

--- a/api/String.cpp
+++ b/api/String.cpp
@@ -45,6 +45,12 @@ String::String(const char *cstr)
 	if (cstr) copy(cstr, strlen(cstr));
 }
 
+String::String(const char *cstr, unsigned int length)
+{
+	init();
+	if (cstr) copy(cstr, length);
+}
+
 String::String(const String &value)
 {
 	init();

--- a/api/String.cpp
+++ b/api/String.cpp
@@ -307,49 +307,49 @@ unsigned char String::concat(unsigned char num)
 {
 	char buf[1 + 3 * sizeof(unsigned char)];
 	itoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(int num)
 {
 	char buf[2 + 3 * sizeof(int)];
 	itoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(unsigned int num)
 {
 	char buf[1 + 3 * sizeof(unsigned int)];
 	utoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(long num)
 {
 	char buf[2 + 3 * sizeof(long)];
 	ltoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(unsigned long num)
 {
 	char buf[1 + 3 * sizeof(unsigned long)];
 	ultoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+	return concat(buf);
 }
 
 unsigned char String::concat(float num)
 {
 	char buf[20];
 	char* string = dtostrf(num, 4, 2, buf);
-	return concat(string, strlen(string));
+	return concat(string);
 }
 
 unsigned char String::concat(double num)
 {
 	char buf[20];
 	char* string = dtostrf(num, 4, 2, buf);
-	return concat(string, strlen(string));
+	return concat(string);
 }
 
 unsigned char String::concat(const __FlashStringHelper * str)
@@ -378,7 +378,7 @@ StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs)
 StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr)
 {
 	StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-	if (!cstr || !a.concat(cstr, strlen(cstr))) a.invalidate();
+	if (!cstr || !a.concat(cstr)) a.invalidate();
 	return a;
 }
 

--- a/api/String.cpp
+++ b/api/String.cpp
@@ -632,10 +632,7 @@ String String::substring(unsigned int left, unsigned int right) const
 	String out;
 	if (left >= len) return out;
 	if (right > len) right = len;
-	char temp = buffer[right];  // save the replaced character
-	buffer[right] = '\0';	
-	out = buffer + left;  // pointer arithmetic
-	buffer[right] = temp;  //restore character
+	out.copy(buffer + left, right - left);
 	return out;
 }
 

--- a/api/String.cpp
+++ b/api/String.cpp
@@ -192,7 +192,7 @@ String & String::copy(const char *cstr, unsigned int length)
 		return *this;
 	}
 	len = length;
-	strcpy(buffer, cstr);
+	memcpy(buffer, cstr, length);
 	return *this;
 }
 
@@ -212,7 +212,7 @@ void String::move(String &rhs)
 {
 	if (buffer) {
 		if (rhs && capacity >= rhs.len) {
-			strcpy(buffer, rhs.buffer);
+			memcpy(buffer, rhs.buffer, rhs.len);
 			len = rhs.len;
 			rhs.len = 0;
 			return;
@@ -284,7 +284,7 @@ unsigned char String::concat(const char *cstr, unsigned int length)
 	if (!cstr) return 0;
 	if (length == 0) return 1;
 	if (!reserve(newlen)) return 0;
-	strcpy(buffer + len, cstr);
+	memcpy(buffer + len, cstr, length);
 	len = newlen;
 	return 1;
 }

--- a/api/String.h
+++ b/api/String.h
@@ -69,6 +69,7 @@ public:
 	// be false).
 	String(const char *cstr = "");
 	String(const char *cstr, unsigned int length);
+	String(const uint8_t *cstr, unsigned int length) : String((const char*)cstr, length) {}
 	String(const String &str);
 	String(const __FlashStringHelper *str);
 	#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)

--- a/api/String.h
+++ b/api/String.h
@@ -109,6 +109,7 @@ public:
 	// concatenation is considered unsucessful.
 	unsigned char concat(const String &str);
 	unsigned char concat(const char *cstr);
+	unsigned char concat(const char *cstr, unsigned int length);
 	unsigned char concat(char c);
 	unsigned char concat(unsigned char num);
 	unsigned char concat(int num);
@@ -225,7 +226,6 @@ protected:
 	void init(void);
 	void invalidate(void);
 	unsigned char changeBuffer(unsigned int maxStrLen);
-	unsigned char concat(const char *cstr, unsigned int length);
 
 	// copy and move
 	String & copy(const char *cstr, unsigned int length);

--- a/api/String.h
+++ b/api/String.h
@@ -111,6 +111,7 @@ public:
 	unsigned char concat(const String &str);
 	unsigned char concat(const char *cstr);
 	unsigned char concat(const char *cstr, unsigned int length);
+	unsigned char concat(const uint8_t *cstr, unsigned int length) {return concat((const char*)cstr, length);}
 	unsigned char concat(char c);
 	unsigned char concat(unsigned char num);
 	unsigned char concat(int num);

--- a/api/String.h
+++ b/api/String.h
@@ -68,6 +68,7 @@ public:
 	// fails, the string will be marked as invalid (i.e. "if (s)" will
 	// be false).
 	String(const char *cstr = "");
+	String(const char *cstr, unsigned int length);
 	String(const String &str);
 	String(const __FlashStringHelper *str);
 	#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)


### PR DESCRIPTION
When working with the Arduino String class, I've found that I couldn't efficiently combine it with some external libraries that explicitely pass char* and length around, without nul-terminating their strings. This prompted me to modify and expose the concat (const char* cstr, unsigned int length) method, add a new String(const char* cstr, unsigned int length) constructor. While I was going over the string class, I found some other minor improvements, which are included here.

This is a port of https://github.com/arduino/Arduino/pull/1936. The commits are  identical, except for some improved commit messages and one commit was dropped since that change was already made by someone else in the meantime.

I've provided some testcases by updating the string examples: https://github.com/arduino/Arduino/pull/9239

If this is ok to merge, I'll also provide a PR for the reference documentation.