### PR TITLE
Some Print / Stream API fixes

### DIFF
--- a/api/Print.h
+++ b/api/Print.h
@@ -82,5 +82,7 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+
+    virtual void flush() { /* Empty implementation for backward compatibility */ }
 };
 

--- a/api/Print.h
+++ b/api/Print.h
@@ -54,6 +54,10 @@ class Print
       return write((const uint8_t *)buffer, size);
     }
 
+    // default to zero, meaning "a single write may block"
+    // should be overriden by subclasses with buffering
+    virtual int availableForWrite() { return 0; }
+
     size_t print(const __FlashStringHelper *);
     size_t print(const String &);
     size_t print(const char[]);

--- a/api/Stream.h
+++ b/api/Stream.h
@@ -58,7 +58,6 @@ class Stream : public Print
     virtual int available() = 0;
     virtual int read() = 0;
     virtual int peek() = 0;
-    virtual void flush() = 0;
 
     Stream() {_timeout=1000;}
 


### PR DESCRIPTION
Moved `flush` method to `Print`.
Added `availableForWrite` method to `Print`.

Fix #102 