### PR TITLE
Fix pgm_read_ptr in AVR pgmspace.h

### DIFF
--- a/api/deprecated-avr-comp/avr/pgmspace.h
+++ b/api/deprecated-avr-comp/avr/pgmspace.h
@@ -103,7 +103,7 @@ typedef const void* uint_farptr_t;
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
 #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
 #define pgm_read_float(addr) (*(const float *)(addr))
-#define pgm_read_ptr(addr) (*(const void *)(addr))
+#define pgm_read_ptr(addr) (*(void *const *)(addr))
 
 #define pgm_read_byte_near(addr) pgm_read_byte(addr)
 #define pgm_read_word_near(addr) pgm_read_word(addr)


### PR DESCRIPTION
Originally, `pgm_read_ptr` used to cast its argument to `const void *`, i.e. a pointer to read-only data.  
This is incorrect, because the argument is a pointer to a pointer in "flash memory". You cannot cast it to
`const void *` and then dereference it, because `void` is not an object type.
Also, the pointer itself is read-only, but the data could in theory be mutable.  
The correct type should be `void *const *`, i.e. a pointer to a read-only pointer to any data.