### PR TITLE
Remove include of Hardware*.h from ArduinoAPI.h

### DIFF
--- a/api/ArduinoAPI.h
+++ b/api/ArduinoAPI.h
@@ -26,7 +26,6 @@
 #include "Binary.h"
 
 #ifdef __cplusplus
-#include "Client.h"
 #include "Interrupts.h"
 #include "IPAddress.h"
 #include "Print.h"

--- a/api/ArduinoAPI.h
+++ b/api/ArduinoAPI.h
@@ -27,9 +27,6 @@
 
 #ifdef __cplusplus
 #include "Client.h"
-#include "HardwareI2C.h"
-#include "HardwareSPI.h"
-#include "HardwareSerial.h"
 #include "Interrupts.h"
 #include "IPAddress.h"
 #include "Print.h"


### PR DESCRIPTION
Hardware related includes can be removed from ArduinoAPI.h since they can be included by the specific interfaces. This gives also the users more flexibility to implement their own classes.

In ArduinoCore-API integration in ArduinoCore-samd, the 3 includes removed form ArduinoAPI.h are, instead, here: 
- [HardwareSerial.h](https://github.com/arduino/ArduinoCore-samd/blob/05db380e9e8524956d66b47b08e3e46596bc6451/cores/arduino/Uart.h#L21)
- [SPI.h](https://github.com/arduino/ArduinoCore-samd/blob/05db380e9e8524956d66b47b08e3e46596bc6451/libraries/SPI/SPI.h#L24)
- [I2C.h](https://github.com/arduino/ArduinoCore-samd/blob/05db380e9e8524956d66b47b08e3e46596bc6451/libraries/Wire/Wire.h#L23)

ArduinoCore-mbed must be modified as well to correctly include this files. This branch [NOHardwareIncludeInAPI](https://github.com/giulcioffi/ArduinoCore-mbed/commit/03ee6c06472f860f05c1dc51226ca6077a7f8117) provides a possible implementation. The CI [workflow](https://github.com/giulcioffi/ArduinoCore-mbed/commit/0cfd5bd50c593646c4b00baccb9768d1ec97f6a8) has been locally modified to ensure that this proposed branch of ArduinoCore-API is checked out. The compilation has been successful: https://github.com/giulcioffi/ArduinoCore-mbed/actions/runs/257232488