### PR TITLE
Use arduino/cpp-test-action in Unit Test CI workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,41 +20,26 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      BUILD_PATH: ${{ github.workspace }}/test/build
+      COVERAGE_DATA_PATH: extras/coverage-data/coverage.info
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install valgrind
-        run: sudo apt-get --assume-yes install valgrind
-
-      - name: Run unit tests
-        run: |
-          mkdir "$BUILD_PATH"
-          cd "$BUILD_PATH"
-          # Generate makefile
-          cmake ..
-          # Compile tests
-          make
-          # Run tests and check for memory leaks
-          valgrind --leak-check=yes --error-exitcode=1 bin/test-ArduinoCore-API
-
-      - name: Install lcov
-        run: sudo apt-get --assume-yes install lcov
-
-      - name: Report code coverage
-        run: |
-          cd "$BUILD_PATH"
-          lcov --directory . --capture --output-file coverage.info
-          # Remove external files from coverage data
-          lcov --quiet --remove coverage.info '*/test/*' '/usr/*' --output-file coverage.info
-          # Print coverage report in the workflow log
-          lcov --list coverage.info
+      # See: https://github.com/arduino/cpp-test-action/blob/main/README.md
+      - uses: arduino/cpp-test-action@main
+        with:
+          source-path: test
+          build-path: test/build
+          runtime-path: test/build/bin/test-ArduinoCore-API
+          coverage-exclude-paths: |
+            - '*/test/*'
+            - '/usr/*'
+          coverage-data-path: ${{ env.COVERAGE_DATA_PATH }}
 
       # See: https://github.com/codecov/codecov-action/blob/master/README.md
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v1
         with:
-          file: ${{ env.BUILD_PATH }}/coverage.info
+          file: ${{ env.COVERAGE_DATA_PATH }}
           fail_ci_if_error: true


### PR DESCRIPTION
The commands used for Arduino's standard firmware test procedure, which were previously duplicated in each workflow, have now been moved to a GitHub Actions action, [arduino/cpp-test-action](https://github.com/arduino/cpp-test-action), allowing for more minimal workflows and the maintenance of these commands in a centralized location.

This PR should result in no functional change to the unit testing and code coverage reporting process.