### PR TITLE
Fix: Allow HardwareI2C::requestFrom to return values > 256

### DIFF
--- a/api/HardwareI2C.h
+++ b/api/HardwareI2C.h
@@ -36,8 +36,8 @@ class HardwareI2C : public Stream
     virtual uint8_t endTransmission(bool stopBit) = 0;
     virtual uint8_t endTransmission(void) = 0;
 
-    virtual uint8_t requestFrom(uint8_t address, size_t len, bool stopBit) = 0;
-    virtual uint8_t requestFrom(uint8_t address, size_t len) = 0;
+    virtual size_t requestFrom(uint8_t address, size_t len, bool stopBit) = 0;
+    virtual size_t requestFrom(uint8_t address, size_t len) = 0;
 
     virtual void onReceive(void(*)(int)) = 0;
     virtual void onRequest(void(*)(void)) = 0;


### PR DESCRIPTION
Changing return type of `requestFrom` from `uint8_t` to `size_t` allows the function to return the correct amount of bytes read (since internally it's already a `size_t` which is downcast to a `uint8_t` upon returning it).

Merging this PR also requires to merge
* https://github.com/arduino/ArduinoCore-samd/pull/442
* https://github.com/arduino/ArduinoCore-megaavr/pull/92
* https://github.com/arduino/ArduinoCore-mbed/pull/97

@facchinm Let's coordinate to get this done.