### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-deprecation.md
+++ b/.github/ISSUE_TEMPLATE/api-deprecation.md
@@ -1,0 +1,25 @@
+---
+name: API deprecation
+about: Suggest the deprecation of an API component defined by ArduinoCore-API.
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+### API component
+
+<!-- Tell us which API component the deprecation applies to. -->
+
+### Description
+
+<!-- A clear and concise description of the suggestion. -->
+<!-- What is the reason for the deprecation? -->
+
+### Replacement API component
+
+<!-- What should be used instead of the deprecated API component? -->
+<!-- Is this replacement available to all users (e.g., is it provided by the C++ standard version used in major boards platforms)? -->
+
+### Additional information
+
+<!-- Add any other context for the suggestion here. -->

--- a/.github/ISSUE_TEMPLATE/api-improvement.md
+++ b/.github/ISSUE_TEMPLATE/api-improvement.md
@@ -1,0 +1,24 @@
+---
+name: API improvement
+about: Suggest an improvement to an existing API component.
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+### API component
+
+<!-- Tell us which API component the improvement applies to. -->
+
+### Description
+
+<!-- A clear and concise description of the suggestion. -->
+
+### Is this a breaking change?
+
+<!-- Would this change require any users to change their code? -->
+<!-- Would this change require any boards platform authors to change their configuration files or release system? -->
+
+### Additional information
+
+<!-- Add any other context for the request here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report problems with the code in this repository.
+title: ""
+labels: bug
+assignees: ""
+---
+
+### Description
+
+<!-- A clear and concise description of the bug. -->
+
+### Environment
+
+- Boards platform name:
+- Boards platform version (as shown in Boards Manager):
+- ArduinoCore-API version (if you manually installed it):
+
+### Current behavior
+
+<!-- Provide a minimal sketch that demonstrates the issue. -->
+
+### Expected behavior
+
+<!-- Describe what you expect to happen when the demonstration sketch is run. -->
+
+### Additional information
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+contact_links:
+  - name: Learn about the Arduino language
+    url: https://www.arduino.cc/reference/en
+    about: User documentation is available at the Arduino language reference.
+  - name: Support request
+    url: https://forum.arduino.cc/
+    about: We can help you out on the Arduino Forum!
+  - name: Discuss ArduinoCore-API development
+    url: https://groups.google.com/a/arduino.cc/g/developers
+    about: Arduino Developers Mailing List

--- a/.github/ISSUE_TEMPLATE/new-api-component.md
+++ b/.github/ISSUE_TEMPLATE/new-api-component.md
@@ -1,0 +1,15 @@
+---
+name: New API component
+about: Suggest the addition of a new API component to ArduinoCore-API.
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+### Description
+
+<!-- A clear and concise description of the API component you want added. -->
+
+### Additional information
+
+<!-- Add any other context for the request here. -->

--- a/.github/ISSUE_TEMPLATE/other-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/other-enhancement.md
@@ -1,0 +1,22 @@
+---
+name: Other enhancement
+about:
+  Suggest an improvement for this project that doesn't fit in the specific categories
+  above.
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+### Description
+
+<!-- A clear and concise description of the enhancement. -->
+
+### Is this a breaking change?
+
+<!-- Would this change require any users to change their code? -->
+<!-- Would this change require any boards platform authors to change their configuration files or release system? -->
+
+### Additional information
+
+<!-- Add any other context for the request here. -->


### PR DESCRIPTION
A menu of issue categories will be presented when the user begins the issue creation process.

The issue will be prefilled with prompts for the specific information needed for each issue type.

If none of the issue types are applicable, the user can click the "Open a blank issue" link at the bottom of the issue template chooser page to get the previous issue creation behavior.

The [default organization level security policy](https://github.com/arduino/.github/blob/master/SECURITY.md) is linked to for people wanting to report a security vulnerability.

Links are provided to the Arduino Language Reference, Arduino Forum, and Arduino Developers Mailing list to redirect support requests.

---
![Clipboard01](https://user-images.githubusercontent.com/8572152/106574379-b31e4980-64ef-11eb-9647-042e929f7c38.png)

---
![Clipboard02](https://user-images.githubusercontent.com/8572152/106574385-b44f7680-64ef-11eb-90dc-f0cabfcbdfbb.png)

---
References:
- https://docs.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates
- https://docs.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository
- https://docs.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser