### PR TITLE
Update math macros to avoid computing callable arguments more than once

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -44,22 +44,22 @@ typedef enum {
 #ifdef __cplusplus
 
   template<class T, class L> 
-  auto min(const T& a, const L& b) -> decltype((b < a) ? b : a)
+  auto min(const T& a, const L& b) -> decltype(b < a ? b : a)
   {
     return (b < a) ? b : a;
   }
 
   template<class T, class L> 
-  auto max(const T& a, const L& b) -> decltype((b < a) ? b : a)
+  auto max(const T& a, const L& b) -> decltype(b < a ? b : a)
   {
     return (a < b) ? b : a;
   }
 
 
   template<class T, class U, class V> 
-  auto constrain(const T& amt, const U& low, const V& high) -> decltype((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
+  auto constrain(const T& amt, const U& low, const V& high) -> decltype(amt < low ? low : (amt > high ? high : amt))
   {
-      return (amt)<(low)?(low):((amt)>(high)?(high):(amt));
+      return amt < low ? low : (amt > high ? high : amt);
   }
   
   template<class T> 
@@ -81,19 +81,29 @@ typedef enum {
   }
 #else
   #ifndef constrain
-  #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
+  #define constrain(amt,low,high) \
+     ({ __typeof__ (amt) _amt = (amt); \
+         __typeof__ (low) _low = (low); \
+         __typeof__ (high) _high = (high); \
+       _amt < _low ? _low : (_amt > _high ? _high :_amt); }
   #endif
   
   #ifndef radians
-  #define radians(deg) ((deg)*DEG_TO_RAD)
+  #define radians(deg) \
+      ({ __typeof__ (deg) _deg = deg; \
+       _deg * DEG_TO_RAD; })
   #endif
   
   #ifndef degrees
-  #define degrees(rad) ((rad)*RAD_TO_DEG)
+  #define degrees(rad) \
+      ({ __typeof__ (rad) _rad = rad; \
+       _rad * RAD_TO_DEG; })
   #endif
   
   #ifndef sq
-  #define sq(x) ((x)*(x))
+  #define sq(x) \
+      ({ __typeof__ (x) _x = x; \
+       _x * _x; })
   #endif
 
   #ifndef min

--- a/api/Common.h
+++ b/api/Common.h
@@ -37,20 +37,82 @@ typedef enum {
 #define SERIAL      0x0
 #define DISPLAY     0x1
 
-#ifndef constrain
-#define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
+#ifdef __cplusplus
+} // extern "C"
 #endif
 
-#ifndef radians
-#define radians(deg) ((deg)*DEG_TO_RAD)
+#ifdef __cplusplus
+
+  template<class T, class L> 
+  auto min(const T& a, const L& b) -> decltype((b < a) ? b : a)
+  {
+    return (b < a) ? b : a;
+  }
+
+  template<class T, class L> 
+  auto max(const T& a, const L& b) -> decltype((b < a) ? b : a)
+  {
+    return (a < b) ? b : a;
+  }
+
+
+  template<class T, class U, class V> 
+  auto constrain(const T& amt, const U& low, const V& high) -> decltype((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
+  {
+      return (amt)<(low)?(low):((amt)>(high)?(high):(amt));
+  }
+  
+  template<class T> 
+  auto radians(const T& deg) -> decltype(deg * DEG_TO_RAD)
+  {
+      return deg * DEG_TO_RAD;
+  }
+
+  template<class T> 
+  auto degrees(const T& rad) -> decltype(rad * RAD_TO_DEG)
+  {
+      return rad * RAD_TO_DEG;
+  }
+
+  template<class T> 
+  auto sq(const T& x) -> decltype(x*x)
+  {
+      return x*x;
+  }
+#else
+  #ifndef constrain
+  #define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
+  #endif
+  
+  #ifndef radians
+  #define radians(deg) ((deg)*DEG_TO_RAD)
+  #endif
+  
+  #ifndef degrees
+  #define degrees(rad) ((rad)*RAD_TO_DEG)
+  #endif
+  
+  #ifndef sq
+  #define sq(x) ((x)*(x))
+  #endif
+
+  #ifndef min
+  #define min(a,b) \
+     ({ __typeof__ (a) _a = (a); \
+         __typeof__ (b) _b = (b); \
+       _a < _b ? _a : _b; })
+  #endif
+
+  #ifndef max
+  #define max(a,b) \
+     ({ __typeof__ (a) _a = (a); \
+         __typeof__ (b) _b = (b); \
+       _a > _b ? _a : _b; })
+  #endif
 #endif
 
-#ifndef degrees
-#define degrees(rad) ((rad)*RAD_TO_DEG)
-#endif
-
-#ifndef sq
-#define sq(x) ((x)*(x))
+#ifdef __cplusplus
+extern "C"{
 #endif
 
 typedef void (*voidFuncPtr)(void);
@@ -119,32 +181,6 @@ void loop(void);
 } // extern "C"
 #endif
 
-#ifdef __cplusplus
-  template<class T, class L> 
-  auto min(const T& a, const L& b) -> decltype((b < a) ? b : a)
-  {
-    return (b < a) ? b : a;
-  }
-
-  template<class T, class L> 
-  auto max(const T& a, const L& b) -> decltype((b < a) ? b : a)
-  {
-    return (a < b) ? b : a;
-  }
-#else
-#ifndef min
-#define min(a,b) \
-   ({ __typeof__ (a) _a = (a); \
-       __typeof__ (b) _b = (b); \
-     _a < _b ? _a : _b; })
-#endif
-#ifndef max
-#define max(a,b) \
-   ({ __typeof__ (a) _a = (a); \
-       __typeof__ (b) _b = (b); \
-     _a > _b ? _a : _b; })
-#endif
-#endif
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
This PR updates various math macros to avoid computing callable arguments more than once using the same technique that the `max` macro currently does. It also replaces them with C++ template functions when `__cplusplus` is defined. [I originally opened this as in the ArduinoCore-avr repo](https://github.com/arduino/ArduinoCore-avr/pull/391), but was directed here.

```
❯ ./test-ArduinoCore-API
===============================================================================
All tests passed (527 assertions in 226 test cases)
```