### PR TITLE
Fix minor misspellings in comments

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -85,7 +85,7 @@ int atexit(void (*func)()) __attribute__((weak));
 int main() __attribute__((weak));
 
 #ifdef EXTENDED_PIN_MODE
-// Platforms who wnat to declare more than 256 pins need to define EXTENDED_PIN_MODE globally
+// Platforms who want to declare more than 256 pins need to define EXTENDED_PIN_MODE globally
 typedef uint32_t pin_size_t;
 #else
 typedef uint8_t pin_size_t;

--- a/api/HardwareSPI.h
+++ b/api/HardwareSPI.h
@@ -124,7 +124,7 @@ class HardwareSPI
     virtual void end() = 0;
 };
 
-// Alias SPIClass to HardwareSPI since it's already the defacto standard for SPI classe name
+// Alias SPIClass to HardwareSPI since it's already the defacto standard for SPI class name
 typedef HardwareSPI SPIClass;
 
 }

--- a/api/IPAddress.h
+++ b/api/IPAddress.h
@@ -23,7 +23,7 @@
 #include "Printable.h"
 #include "String.h"
 
-// forward declartions of global name space friend classes
+// forward declarations of global name space friend classes
 class EthernetClass;
 class DhcpClass;
 class DNSClient;

--- a/api/Print.h
+++ b/api/Print.h
@@ -57,7 +57,7 @@ class Print
     }
 
     // default to zero, meaning "a single write may block"
-    // should be overriden by subclasses with buffering
+    // should be overridden by subclasses with buffering
     virtual int availableForWrite() { return 0; }
 
     size_t print(const __FlashStringHelper *);

--- a/api/Stream.h
+++ b/api/Stream.h
@@ -24,7 +24,7 @@
 #include <inttypes.h>
 #include "Print.h"
 
-// compatability macros for testing
+// compatibility macros for testing
 /*
 #define   getInt()            parseInt()
 #define   getInt(ignore)      parseInt(ignore)

--- a/api/String.h
+++ b/api/String.h
@@ -106,7 +106,7 @@ public:
 
 	// returns true on success, false on failure (in which case, the string
 	// is left unchanged).  if the argument is null or invalid, the
-	// concatenation is considered unsucessful.
+	// concatenation is considered unsuccessful.
 	bool concat(const String &str);
 	bool concat(const char *cstr);
 	bool concat(const char *cstr, unsigned int length);
@@ -179,7 +179,7 @@ public:
 	bool startsWith(const String &prefix, unsigned int offset) const;
 	bool endsWith(const String &suffix) const;
 
-	// character acccess
+	// character access
 	char charAt(unsigned int index) const;
 	void setCharAt(unsigned int index, char c);
 	char operator [] (unsigned int index) const;


### PR DESCRIPTION
Codespell detected a few minor typos in the API headers.  Fix their spelling.