### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,7 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list = hel
+check-filenames =
+check-hidden =
+skip = ./.git,./test/external

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Spell check
+        uses: codespell-project/actions-codespell@master

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,7 @@ name: Unit Tests
 
 on:
   pull_request:
-    # Only run workflow if a file in these paths are modified
+    # Only run workflow if a file in these paths is modified
     paths:
       - ".github/workflows/unit-tests.yml"
       - "test/**"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository hosts the hardware independent layer of Arduino core.
 All Arduino official cores are being ported to the new structure so they take advantage of this single repo.
 
 Including this repo in your existing Arduino core will allow the language to grow and include new features.
-For backwards compatibility, every revision of this repo will increase `ARDUINO_API_VERSION` define.
+For backwards compatibility, every revision of this repo will increase the `ARDUINO_API_VERSION` define.
 
 Some cores have been ported to the new structure, for example:
 * megaAVR (https://github.com/arduino/ArduinoCore-megaAVR) 
@@ -21,7 +21,7 @@ These repositories **don't** contain the needed `api` subfolder; to "complete" t
 
 ### Porting tips
 
-In the future, core apis will be updated independently from the core, so all the compatible cores will seamlessly adopt new features.
+In the future, core APIs will be updated independently from the core, so all the compatible cores will seamlessly adopt new features.
 This requires support from all the IDEs, so in the meantime we suggest to release the core by copying a snapshot of this `api` folder.
 
 The most elegant and effective solution is to develop the core with `api` symlinked and produce the distributable archive by telling `tar` to follow symlinks. 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Unit Tests](https://github.com/arduino/ArduinoCore-API/workflows/Unit%20Tests/badge.svg)](https://github.com/arduino/ArduinoCore-API/actions?workflow=Unit+Tests)
 [![codecov](https://codecov.io/gh/arduino/ArduinoCore-API/branch/master/graph/badge.svg)](https://codecov.io/gh/arduino/ArduinoCore-API)
+[![Spell Check status](https://github.com/arduino/ArduinoCore-API/actions/workflows/spell-check.yml/badge.svg)](https://github.com/arduino/ArduinoCore-API/actions/workflows/spell-check.yml)
 
 This repository hosts the hardware independent layer of Arduino core.
 

--- a/api/IPAddress.cpp
+++ b/api/IPAddress.cpp
@@ -66,7 +66,7 @@ bool IPAddress::fromString(const char *address)
         else if (c == '.')
         {
             if (dots == 3) {
-                // Too much dots (there must be 3 dots)
+                // Too many dots (there must be 3 dots)
                 return false;
             }
             if (acc < 0) {

--- a/api/Udp.h
+++ b/api/Udp.h
@@ -48,10 +48,10 @@ public:
 
   // Sending UDP packets
   
-  // Start building up a packet to send to the remote host specific in ip and port
+  // Start building up a packet to send to the remote host specified in ip and port
   // Returns 1 if successful, 0 if there was a problem with the supplied IP address or port
   virtual int beginPacket(IPAddress ip, uint16_t port) =0;
-  // Start building up a packet to send to the remote host specific in host and port
+  // Start building up a packet to send to the remote host specified in host and port
   // Returns 1 if successful, 0 if there was a problem resolving the hostname or port
   virtual int beginPacket(const char *host, uint16_t port) =0;
   // Finish off this packet and send it

--- a/api/deprecated-avr-comp/avr/interrupt.h
+++ b/api/deprecated-avr-comp/avr/interrupt.h
@@ -19,5 +19,5 @@
 /*
   Empty file.
   This file is here to allow compatibility with sketches (made for AVR)
-  that includes <AVR/interrupt.h>
+  that include <AVR/interrupt.h>
 */

--- a/api/deprecated/Client.h
+++ b/api/deprecated/Client.h
@@ -18,7 +18,7 @@
 
 // including Client.h is deprecated, for all future projects use Arduino.h instead
 
-// This include is added for compatibility, it will be remove on the next
+// This include is added for compatibility, it will be removed on the next
 // major release of the API
 #include "../Client.h"
 

--- a/api/deprecated/HardwareSerial.h
+++ b/api/deprecated/HardwareSerial.h
@@ -18,7 +18,7 @@
 
 // including HardwareSerial.h is deprecated, for all future projects use Arduino.h instead
 
-// This include is added for compatibility, it will be remove on the next
+// This include is added for compatibility, it will be removed on the next
 // major release of the API
 #include "../HardwareSerial.h"
 

--- a/api/deprecated/IPAddress.h
+++ b/api/deprecated/IPAddress.h
@@ -18,7 +18,7 @@
 
 // including IPAddress.h is deprecated, for all future projects use Arduino.h instead
 
-// This include is added for compatibility, it will be remove on the next
+// This include is added for compatibility, it will be removed on the next
 // major release of the API
 #include "../IPAddress.h"
 

--- a/api/deprecated/Print.h
+++ b/api/deprecated/Print.h
@@ -18,7 +18,7 @@
 
 // including Print.h is deprecated, for all future projects use Arduino.h instead
 
-// This include is added for compatibility, it will be remove on the next
+// This include is added for compatibility, it will be removed on the next
 // major release of the API
 #include "../Print.h"
 

--- a/api/deprecated/Printable.h
+++ b/api/deprecated/Printable.h
@@ -18,7 +18,7 @@
 
 // including Printable.h is deprecated, for all future projects use Arduino.h instead
 
-// This include is added for compatibility, it will be remove on the next
+// This include is added for compatibility, it will be removed on the next
 // major release of the API
 #include "../Printable.h"
 

--- a/api/deprecated/Server.h
+++ b/api/deprecated/Server.h
@@ -18,7 +18,7 @@
 
 // including Server.h is deprecated, for all future projects use Arduino.h instead
 
-// This include is added for compatibility, it will be remove on the next
+// This include is added for compatibility, it will be removed on the next
 // major release of the API
 #include "../Server.h"
 

--- a/api/deprecated/Stream.h
+++ b/api/deprecated/Stream.h
@@ -18,7 +18,7 @@
 
 // including Stream.h is deprecated, for all future projects use Arduino.h instead
 
-// This include is added for compatibility, it will be remove on the next
+// This include is added for compatibility, it will be removed on the next
 // major release of the API
 #include "../Stream.h"
 

--- a/api/deprecated/Udp.h
+++ b/api/deprecated/Udp.h
@@ -18,7 +18,7 @@
 
 // including Udp.h is deprecated, for all future projects use Arduino.h instead
 
-// This include is added for compatibility, it will be remove on the next
+// This include is added for compatibility, it will be removed on the next
 // major release of the API
 #include "../Udp.h"
 

--- a/api/deprecated/WString.h
+++ b/api/deprecated/WString.h
@@ -18,7 +18,7 @@
 
 // including WString.h is deprecated, for all future projects use Arduino.h instead
 
-// This include is added for compatibility, it will be remove on the next
+// This include is added for compatibility, it will be removed on the next
 // major release of the API
 #include "../String.h"
 

--- a/test/src/Stream/test_readBytes.cpp
+++ b/test/src/Stream/test_readBytes.cpp
@@ -25,7 +25,7 @@ TEST_CASE ("Testing readBytes(char *buffer, size_t length)", "[Stream-readBytes-
     REQUIRE(mock.readBytes(buf, sizeof(buf)) == 0);
   }
 
-  WHEN ("the stream contains less data then we want to read")
+  WHEN ("the stream contains less data than we want to read")
   {
     char buf[32] = {0};
     char const str[] = "some stream content";
@@ -36,7 +36,7 @@ TEST_CASE ("Testing readBytes(char *buffer, size_t length)", "[Stream-readBytes-
     REQUIRE(mock.readString() == arduino::String(""));
   }
 
-  WHEN ("the stream contains more data then we want to read")
+  WHEN ("the stream contains more data than we want to read")
   {
     char buf[5] = {0};
     mock << "some stream content";

--- a/test/src/String/test_replace.cpp
+++ b/test/src/String/test_replace.cpp
@@ -39,14 +39,14 @@ TEST_CASE ("Testing String::replace(char, char) when string contains elements = 
   REQUIRE(str == "H3ll0 Ardu1n0!");
 }
 
-TEST_CASE ("Testing String::replace(String, String) when string does not constain subtr 'find'", "[String-replace-04]")
+TEST_CASE ("Testing String::replace(String, String) when string does not contain substr 'find'", "[String-replace-04]")
 {
   arduino::String str("Hello Arduino!");
   str.replace(arduino::String("Zulu"), arduino::String("11"));
   REQUIRE(str == "Hello Arduino!");
 }
 
-TEST_CASE ("Testing String::replace(String, String) when string constains subtr 'find'", "[String-replace-05]")
+TEST_CASE ("Testing String::replace(String, String) when string contains substr 'find'", "[String-replace-05]")
 {
   arduino::String str("Hello Arduino!");
   str.replace(arduino::String("ll"), arduino::String("11"));

--- a/test/src/String/test_trim.cpp
+++ b/test/src/String/test_trim.cpp
@@ -30,7 +30,7 @@ TEST_CASE ("Testing String::trim with space at the end", "[String-trim-02]")
   REQUIRE(str == "hello");
 }
 
-TEST_CASE ("Testing String::trim with space at both beginng and end", "[String-trim-03]")
+TEST_CASE ("Testing String::trim with space at both beginning and end", "[String-trim-03]")
 {
   arduino::String str("  hello  ");
   str.trim();


### PR DESCRIPTION
On every push, pull request, and periodically, use [the `codespell-project/actions-codespell` action](https://github.com/codespell-project/actions-codespell) to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `./.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.
