### PR TITLE
Fix bitWrite with parenthesis

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -65,7 +65,7 @@ typedef void (*voidFuncPtrParam)(void*);
 #define bitSet(value, bit) ((value) |= (1UL << (bit)))
 #define bitClear(value, bit) ((value) &= ~(1UL << (bit)))
 #define bitToggle(value, bit) ((value) ^= (1UL << (bit)))
-#define bitWrite(value, bit, bitvalue) (bitvalue ? bitSet(value, bit) : bitClear(value, bit))
+#define bitWrite(value, bit, bitvalue) ((bitvalue) ? bitSet((value), (bit)) : bitClear((value), (bit)))
 
 #ifndef bit
 #define bit(b) (1UL << (b))


### PR DESCRIPTION
Current version does not wrap arguments in "()", so works incorrectly when used like this:
```
bitWrite(var, bit, cond?1:0);
```

Fixes #153 