### PR TITLE
Add a new 'OUTPUT_OPENDRAIN' pinmode for platforms.

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -16,10 +16,11 @@ typedef enum {
 } PinStatus;
 
 typedef enum {
-  INPUT           = 0x0,
-  OUTPUT          = 0x1,
-  INPUT_PULLUP    = 0x2,
-  INPUT_PULLDOWN  = 0x3,
+  INPUT            = 0x0,
+  OUTPUT           = 0x1,
+  INPUT_PULLUP     = 0x2,
+  INPUT_PULLDOWN   = 0x3,
+  OUTPUT_OPENDRAIN = 0x4,
 } PinMode;
 
 typedef enum {


### PR DESCRIPTION
Not every MCU offers open drain pins, but some do. This change
means that they'll no longer have to play games to implement an
API-compatible pinMode() function that offers open drain.

Fixes #155

If you're reading this commit message because you need to add another
pin mode to this enum, the hacky trivial workaround is to do something
like this in your core:

```
// This typedef is used to extend the PinMode typedef enum
// in the ArduinoAPI, since they don't have contants
typedef enum {
        INPUT_ANALOG = 99 , // We assume that the Arduino core will never have 99 PinModes
        OUTPUT_OPEN_DRAIN   // It'd be cleaner to be able to count the size of that enum
} PinModeExtension;
```

Because PinMode is an enum and not a proper type, the compiler will
let the user pass either a PinMode or a PinModeExtension to your
pinMode() function, even though the signature is
`void pinMode(pin_size_t ulPin, PinMode ulMode)`