### PR TITLE
Adding maxspeed to shiftIn and shiftOut

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -107,7 +107,10 @@ unsigned long pulseIn(pin_size_t pin, uint8_t state, unsigned long timeout);
 unsigned long pulseInLong(pin_size_t pin, uint8_t state, unsigned long timeout);
 
 void shiftOut(pin_size_t dataPin, pin_size_t clockPin, BitOrder bitOrder, uint8_t val);
+void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val, unsigned long maxSpeed = 0);
+
 uint8_t shiftIn(pin_size_t dataPin, pin_size_t clockPin, BitOrder bitOrder);
+uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, unsigned long maxSpeed = 0);  
 
 void attachInterrupt(pin_size_t interruptNumber, voidFuncPtr callback, PinStatus mode);
 void attachInterruptParam(pin_size_t interruptNumber, voidFuncPtrParam callback, PinStatus mode, void* param);


### PR DESCRIPTION
Allowing the user to set the max speed will enable newer faster Arduino based MCU's to control older devices that need slower clock speeds to function. 

https://github.com/arduino/ArduinoCore-API/issues/83