### PR TITLE
Fix including "Arduino.h" from C files

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C"{


### PR DESCRIPTION
Consider [the following sketch]((https://github.com/arduino/ArduinoCore-API/files/8864943/demo-portenta-issue.zip)), to be run on the Portenta H7. We have a `project.ino` file with the following:
```c++
#include "extra.c"

void setup() {}

void loop() {
  blink();
}
```
We also have an `extra.c` file in the sketch folder with the following:
```c
#include "Arduino.h"

void blink() {
  digitalWrite(LED_BUILTIN, HIGH);
  delay(250);
  digitalWrite(LED_BUILTIN, LOW);

  delay(250);
}
```
You can [download the zipped sketch here](https://github.com/arduino/ArduinoCore-API/files/8864943/demo-portenta-issue.zip).

------------------------
This is a valid sketch, and it compiles on most boards (the Arduino Uno, the Nano 33 BLE, the Arduino Due, etc). On the Portenta, however, we get the following error:

```
In file included from /home/guberti/.arduino15/packages/arduino/hardware/mbed_portenta/3.1.1/variants/PORTENTA_H7_M7/pinmode_arduino.h:30:0,
                 from /home/guberti/.arduino15/packages/arduino/hardware/mbed_portenta/3.1.1/cores/arduino/Arduino.h:26,
                 from /home/guberti/Arduino/demo-portenta-issue/extra.c:1:
/home/guberti/.arduino15/packages/arduino/hardware/mbed_portenta/3.1.1/cores/arduino/api/Common.h:76:9: error: unknown type name 'bool'
 typedef bool      boolean;
         ^~~~
exit status 1
Error compiling for board Arduino Portenta H7 (M7 core).
```

This occurs because we do not include `stdbool.h`. We could fix the issue by removing the `typedef bool      boolean;` (it is not used, and the comment suggests someone has been considering it for a while), but just adding the include seems safer.

This PR fixes the issue by adding `#include <stdbool.h>` at the top of `api/Common.h`.
