### PR TITLE
Add some basic build instructions to run unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ Please help us improve the coverage of the test suite!
 
 The unit tests are automatically built by GitHub as part of pull request checks (in `.github/workflows/unit-tests.yml`).
 
-To build and run locally (from the project root):
+To build and run locally:
+
+**Dependencies**
+
+* CMake
+* make
+* gcc
+
+From the project root:
 
 ```
 cmake -S test -B test/build

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ This repository includes a test suite that covers most of the API and that is de
 
 Please help us improve the coverage of the test suite!
 
+#### To build and run unit tests
+
+The unit tests are automatically built by GitHub as part of pull request checks (in `.github/workflows/unit-tests.yml`).
+
+To build and run locally (from the project root):
+
+```
+cmake -S test -B test/build
+make --directory test/build
+test/build/bin/test-ArduinoCore-API
+```
+
 ### Implementing ArduinoCore-API
 
 In order to compile a core which is implementing ArduinoCore-API you'll need to copy/symlink the `api` directory to the target's `cores/arduino` directory as part of your development and release workflow. The most elegant and effective solution is to develop your core with `api` symlinked and produce the distributable archive by telling `tar` to follow symlinks. Example:

--- a/README.md
+++ b/README.md
@@ -52,13 +52,18 @@ To build and run locally:
 
 **Dependencies**
 
-* CMake
-* make
-* gcc
+* [CMake](https://cmake.org/)
+* [GCC](https://gcc.gnu.org/)
+
+On (Ubuntu) Linux run:
+
+```bash
+sudo apt-get install build-essential cmake
+```
 
 From the project root:
 
-```
+```bash
 cd test && mkdir build && cd build
 cmake ..
 make && bin/test-ArduinoCore-API
@@ -68,7 +73,7 @@ make && bin/test-ArduinoCore-API
 
 In order to compile a core which is implementing ArduinoCore-API you'll need to copy/symlink the `api` directory to the target's `cores/arduino` directory as part of your development and release workflow. The most elegant and effective solution is to develop your core with `api` symlinked and produce the distributable archive by telling `tar` to follow symlinks. Example:
 
-```
+```bash
 tar --exclude='*.git*' -cjhvf $yourcore-$version.tar.bz2 $yourcore/
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ To build and run locally:
 From the project root:
 
 ```
-cmake -S test -B test/build
-make --directory test/build
-test/build/bin/test-ArduinoCore-API
+cd test && mkdir build && cd build
+cmake ..
+make && bin/test-ArduinoCore-API
 ```
 
 ### Implementing ArduinoCore-API


### PR DESCRIPTION
These build instructions were reverse engineered out of the github actions (diving into arduino/cpp-test-action).

I think the dependencies are correct, but my machine already had a bunch of software installed, so I'm not sure (but it is a start).

This is useful for someone who wants to contribute to the repo, to run the host-based tests locally (before submitting).

(Note: I also had to make a minor change in `catch.hpp`, to set `sigStackSize = 32768`, as `MINSIGSTKSZ` was no longer defined (some kind of version incompatibility). I have not checked that change in.)