### PR TITLE
Add functions stub for compatibility with very minimal libc

### DIFF
--- a/api/Print.cpp
+++ b/api/Print.cpp
@@ -26,6 +26,11 @@
 using namespace arduino;
 
 // Public Methods //////////////////////////////////////////////////////////////
+#ifdef __VERY_MINIMAL_LIBC__
+// These functions should be implemented in the user code (C++)
+bool isnan(float x);
+bool isinf(float x);
+#endif
 
 /* default implementation: may be overridden */
 size_t Print::write(const uint8_t *buffer, size_t size)

--- a/api/String.cpp
+++ b/api/String.cpp
@@ -26,6 +26,12 @@
 
 #include <float.h>
 
+#ifdef __VERY_MINIMAL_LIBC__
+// These functions should be implemented in the user code (C++)
+long atol(char* c);
+float atof(char* c);
+#endif
+
 namespace arduino {
 
 /*********************************************/


### PR DESCRIPTION
In case the user needs to call the functions from Print/String, these placeholders should be implemented (with C++ scope)