### PR TITLE
Fix stack buffer overflow in String::getBytes() test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -121,8 +121,8 @@ add_compile_definitions(HOST)
 add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 add_compile_options(-Wno-cast-function-type)
 
-set(CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   "--coverage")
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "--coverage -Wno-deprecated-copy")
+set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} --coverage")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage -Wno-deprecated-copy")
 
 ##########################################################################
 

--- a/test/src/String/test_characterAccessFunc.cpp
+++ b/test/src/String/test_characterAccessFunc.cpp
@@ -45,10 +45,11 @@ TEST_CASE ("Testing String::getBytes(unsigned char, unsigned int, unsigned int)"
 
   WHEN("Valid operation") {
     arduino::String str("Hello");
-    unsigned char buf[2];
+    unsigned char buf[3];
     str.getBytes(buf, 5, 3);
     REQUIRE(buf[0] == 'l');
     REQUIRE(buf[1] == 'o');
+    REQUIRE(buf[2] == '\0');
   }
 }
 


### PR DESCRIPTION
- Fixes a stack buffer overflow in the `[String-getBytes-02]` test.
- Fixes the concatenation of the `CMAKE_{C,CXX}_FLAGS` variable in `test/CMakeLists.txt` (string concatenation instead of list concatenation).

This was caught by the GCC sanitizers. It might be a good idea to run the tests with `-fsanitize=address,undefined` in the CI (in addition to Valgrind) to catch these kinds of bugs early.
