### PR TITLE
Extend CanMsg to allow to distinguish between standard and extended ids …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.idea/

--- a/api/CanMsg.cpp
+++ b/api/CanMsg.cpp
@@ -22,7 +22,7 @@ namespace arduino
  * STATIC CONST DEFINITION
  **************************************************************************************/
 
-size_t   const CanMsg::MAX_DATA_LENGTH;
+uint8_t  const CanMsg::MAX_DATA_LENGTH;
 uint32_t const CanMsg::CAN_EFF_FLAG;
 uint32_t const CanMsg::CAN_SFF_MASK;
 uint32_t const CanMsg::CAN_EFF_MASK;

--- a/api/CanMsg.cpp
+++ b/api/CanMsg.cpp
@@ -1,0 +1,34 @@
+/*
+ * This file is free software; you can redistribute it and/or modify
+ * it under the terms of either the GNU General Public License version 2
+ * or the GNU Lesser General Public License version 2.1, both as
+ * published by the Free Software Foundation.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include "CanMsg.h"
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+namespace arduino
+{
+
+/**************************************************************************************
+ * STATIC CONST DEFINITION
+ **************************************************************************************/
+
+size_t   const CanMsg::MAX_DATA_LENGTH;
+uint32_t const CanMsg::CAN_EFF_FLAG;
+uint32_t const CanMsg::CAN_SFF_MASK;
+uint32_t const CanMsg::CAN_EFF_MASK;
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+} /* arduino */

--- a/api/CanMsg.h
+++ b/api/CanMsg.h
@@ -15,7 +15,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <Arduino.h>
+#include "Print.h"
+#include "Printable.h"
+#include "Common.h"
 
 /**************************************************************************************
  * NAMESPACE
@@ -112,20 +114,20 @@ public:
    * |- Bit   29 : reserved (future error frame flag)
    * |- Bit 0-28 : CAN identifier (11/29 bit)
    */
-  uint32_t id;
-  uint8_t  data_length;
-  uint8_t  data[MAX_DATA_LENGTH];
+  private: uint32_t id;
+  public:  uint8_t  data_length;
+  public:  uint8_t  data[MAX_DATA_LENGTH];
 };
 
 /**************************************************************************************
  * FREE FUNCTIONS
  **************************************************************************************/
 
-static uint32_t CanStandardId(uint32_t const id) {
+inline uint32_t CanStandardId(uint32_t const id) {
   return (id & CanMsg::CAN_SFF_MASK);
 }
 
-static uint32_t CanExtendedId(uint32_t const id) {
+inline uint32_t CanExtendedId(uint32_t const id) {
   return (CanMsg::CAN_EFF_FLAG | (id & CanMsg::CAN_EFF_MASK));
 }
 

--- a/api/CanMsg.h
+++ b/api/CanMsg.h
@@ -114,9 +114,9 @@ public:
    * |- Bit   29 : reserved (future error frame flag)
    * |- Bit 0-28 : CAN identifier (11/29 bit)
    */
-  private: uint32_t id;
-  public:  uint8_t  data_length;
-  public:  uint8_t  data[MAX_DATA_LENGTH];
+  uint32_t id;
+  uint8_t  data_length;
+  uint8_t  data[MAX_DATA_LENGTH];
 };
 
 /**************************************************************************************

--- a/api/CanMsg.h
+++ b/api/CanMsg.h
@@ -74,9 +74,9 @@ public:
 
     /* Print the header. */
     if (isStandardId())
-      len = snprintf(buf, sizeof(buf), "[%03X] (%d) : ", id, data_length);
+      len = snprintf(buf, sizeof(buf), "[%03X] (%d) : ", getStandardId(), data_length);
     else
-      len = snprintf(buf, sizeof(buf), "[%08X] (%d) : ", id, data_length);
+      len = snprintf(buf, sizeof(buf), "[%08X] (%d) : ", getExtendedId(), data_length);
     size_t n = p.write(buf, len);
 
     /* Print the data. */

--- a/api/CanMsg.h
+++ b/api/CanMsg.h
@@ -59,14 +59,15 @@ public:
 
   virtual ~CanMsg() { }
 
-  void operator = (CanMsg const & other)
+  CanMsg & operator = (CanMsg const & other)
   {
-    if (this == &other)
-      return;
-
-    this->id          = other.id;
-    this->data_length = other.data_length;
-    memcpy(this->data, other.data, this->data_length);
+    if (this != &other)
+    {
+      this->id          = other.id;
+      this->data_length = other.data_length;
+      memcpy(this->data, other.data, this->data_length);
+    }
+    return (*this);
   }
 
   virtual size_t printTo(Print & p) const override

--- a/api/CanMsg.h
+++ b/api/CanMsg.h
@@ -33,7 +33,7 @@ namespace arduino
 class CanMsg : public Printable
 {
 public:
-  static size_t   constexpr MAX_DATA_LENGTH = 8;
+  static uint8_t  constexpr MAX_DATA_LENGTH = 8;
 
   static uint32_t constexpr CAN_EFF_FLAG    = 0x80000000U;
   static uint32_t constexpr CAN_SFF_MASK    = 0x000007FFU; /* standard frame format (SFF) */
@@ -42,10 +42,10 @@ public:
 
   CanMsg(uint32_t const can_id, uint8_t const can_data_len, uint8_t const * can_data_ptr)
   : id{can_id}
-  , data_length{can_data_len}
+  , data_length{min(can_data_len, MAX_DATA_LENGTH)}
   , data{0}
   {
-    memcpy(data, can_data_ptr, min(can_data_len, MAX_DATA_LENGTH));
+    memcpy(data, can_data_ptr, data_length);
   }
 
   CanMsg() : CanMsg(0, 0, nullptr) { }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,8 @@ set(TEST_SRCS
   src/CanMsg/test_CanStandardId.cpp
   src/CanMsg/test_isExtendedId.cpp
   src/CanMsg/test_isStandardId.cpp
+  src/CanMsg/test_operator_assignment.cpp
+  src/CanMsg/test_printTo.cpp
   src/Common/test_makeWord.cpp
   src/Common/test_map.cpp
   src/Common/test_max.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TEST_TARGET ${CMAKE_PROJECT_NAME})
 
 set(TEST_SRCS
   src/CanMsg/test_CanMsg.cpp
+  src/CanMsg/test_CanMsg_CopyCtor.cpp
   src/CanMsg/test_CanExtendedId.cpp
   src/CanMsg/test_CanStandardId.cpp
   src/CanMsg/test_isExtendedId.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEST_TARGET ${CMAKE_PROJECT_NAME})
 ##########################################################################
 
 set(TEST_SRCS
+  src/CanMsg/test_CanMsg.cpp
   src/CanMsg/test_CanExtendedId.cpp
   src/CanMsg/test_CanStandardId.cpp
   src/CanMsg/test_isExtendedId.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,10 @@ set(TEST_TARGET ${CMAKE_PROJECT_NAME})
 ##########################################################################
 
 set(TEST_SRCS
+  src/CanMsg/test_CanExtendedId.cpp
+  src/CanMsg/test_CanStandardId.cpp
+  src/CanMsg/test_isExtendedId.cpp
+  src/CanMsg/test_isStandardId.cpp
   src/Common/test_makeWord.cpp
   src/Common/test_map.cpp
   src/Common/test_max.cpp
@@ -95,6 +99,7 @@ set(TEST_SRCS
 )
 
 set(TEST_DUT_SRCS
+  ../api/CanMsg.cpp
   ../api/Common.cpp
   ../api/IPAddress.cpp
   ../api/String.cpp

--- a/test/src/CanMsg/test_CanExtendedId.cpp
+++ b/test/src/CanMsg/test_CanExtendedId.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020 Arduino.  All rights reserved.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <catch.hpp>
+
+#include <CanMsg.h>
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+using namespace arduino;
+
+/**************************************************************************************
+ * TEST CODE
+ **************************************************************************************/
+
+TEST_CASE ("Verify correct conversion to 29-Bit CAN ID for lowest valid 29-Bit CAN ID", "[CanMsg-CanExtendedId-01]")
+{
+  REQUIRE(CanExtendedId(0) == (CanMsg::CAN_EFF_FLAG | 0U));
+}
+
+TEST_CASE ("Verify correct conversion to 29-Bit CAN ID for highest valid 29-Bit CAN ID", "[CanMsg-CanExtendedId-02]")
+{
+  REQUIRE(CanExtendedId(0x1FFFFFFFU) == (CanMsg::CAN_EFF_FLAG | 0x1FFFFFFFU));
+}
+
+TEST_CASE ("Verify capping of CAN IDs exceeding 29-Bit CAN ID range", "[CanMsg-CanExtendedId-03]")
+{
+  REQUIRE(CanExtendedId(0x2FFFFFFFU) == (CanMsg::CAN_EFF_FLAG | 0x0FFFFFFFU));
+  REQUIRE(CanExtendedId(0x3FFFFFFFU) == (CanMsg::CAN_EFF_FLAG | 0x1FFFFFFFU));
+  REQUIRE(CanExtendedId(0x4FFFFFFFU) == (CanMsg::CAN_EFF_FLAG | 0x0FFFFFFFU));
+  REQUIRE(CanExtendedId(0x5FFFFFFFU) == (CanMsg::CAN_EFF_FLAG | 0x1FFFFFFFU));
+  /* ... */
+  REQUIRE(CanExtendedId(0xFFFFFFFFU) == (CanMsg::CAN_EFF_FLAG | 0x1FFFFFFFU));
+}

--- a/test/src/CanMsg/test_CanMsg.cpp
+++ b/test/src/CanMsg/test_CanMsg.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Arduino.  All rights reserved.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <catch.hpp>
+
+#include <CanMsg.h>
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+using namespace arduino;
+
+/**************************************************************************************
+ * TEST CODE
+ **************************************************************************************/
+
+TEST_CASE ("Test constructor with no data (data length = 0)", "[CanMsg-CanMsg-01]")
+{
+  CanMsg const msg(CanStandardId(0x20), 0, nullptr);
+
+  REQUIRE(msg.data_length == 0);
+  for (size_t i = 0; i < CanMsg::MAX_DATA_LENGTH; i++)
+    REQUIRE(msg.data[i] == 0);
+}
+
+TEST_CASE ("Test constructor with data (data length < CanMsg::MAX_DATA_LENGTH)", "[CanMsg-CanMsg-02]")
+{
+  uint8_t const msg_data[4] = {0xDE, 0xAD, 0xC0, 0xDE};
+
+  CanMsg const msg(CanStandardId(0x20), sizeof(msg_data), msg_data);
+
+  REQUIRE(msg.data_length == 4);
+  for (size_t i = 0; i < msg.data_length; i++)
+    REQUIRE(msg.data[i] == msg_data[i]);
+}
+
+TEST_CASE ("Test constructor with data (data length > CanMsg::MAX_DATA_LENGTH)", "[CanMsg-CanMsg-03]")
+{
+  uint8_t const msg_data[12] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+  CanMsg const msg(CanStandardId(0x20), sizeof(msg_data), msg_data);
+
+  REQUIRE(msg.data_length == 8);
+  for (size_t i = 0; i < msg.data_length; i++)
+    REQUIRE(msg.data[i] == msg_data[i]);
+}

--- a/test/src/CanMsg/test_CanMsg.cpp
+++ b/test/src/CanMsg/test_CanMsg.cpp
@@ -50,3 +50,17 @@ TEST_CASE ("Test constructor with data (data length > CanMsg::MAX_DATA_LENGTH)",
   for (size_t i = 0; i < msg.data_length; i++)
     REQUIRE(msg.data[i] == msg_data[i]);
 }
+
+TEST_CASE ("Test constructor constructing a CAN frame with standard ID", "[CanMsg-CanMsg-04]")
+{
+  CanMsg const msg(CanStandardId(0x20), 0, nullptr);
+
+  REQUIRE(msg.id == 0x20);
+}
+
+TEST_CASE ("Test constructor constructing a CAN frame with extended ID", "[CanMsg-CanMsg-05]")
+{
+  CanMsg const msg(CanExtendedId(0x20), 0, nullptr);
+
+  REQUIRE(msg.id == (CanMsg::CAN_EFF_FLAG | 0x20));
+}

--- a/test/src/CanMsg/test_CanMsg_CopyCtor.cpp
+++ b/test/src/CanMsg/test_CanMsg_CopyCtor.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Arduino.  All rights reserved.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <catch.hpp>
+
+#include <CanMsg.h>
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+using namespace arduino;
+
+/**************************************************************************************
+ * TEST CODE
+ **************************************************************************************/
+
+TEST_CASE ("Test copy constructor", "[CanMsg-CopyCtor-01]")
+{
+  uint8_t const msg_data[4] = {0xDE, 0xAD, 0xC0, 0xDE};
+
+  CanMsg const msg_1(CanStandardId(0x20), sizeof(msg_data), msg_data);
+  CanMsg const msg_2(msg_1);
+
+  REQUIRE(msg_1.data_length == msg_2.data_length);
+
+  for (size_t i = 0; i < msg_1.data_length; i++)
+  {
+    REQUIRE(msg_1.data[i] == msg_data[i]);
+    REQUIRE(msg_2.data[i] == msg_data[i]);
+  }
+
+}

--- a/test/src/CanMsg/test_CanStandardId.cpp
+++ b/test/src/CanMsg/test_CanStandardId.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020 Arduino.  All rights reserved.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <catch.hpp>
+
+#include <CanMsg.h>
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+using namespace arduino;
+
+/**************************************************************************************
+ * TEST CODE
+ **************************************************************************************/
+
+TEST_CASE ("Verify correct conversion to 11-Bit CAN ID for lowest valid 11-Bit CAN ID", "[CanMsg-CanStandardId-01]")
+{
+  REQUIRE(CanStandardId(0) == 0U);
+}
+
+TEST_CASE ("Verify correct conversion to 11-Bit CAN ID for highest valid 11-Bit CAN ID", "[CanMsg-CanStandardId-02]")
+{
+  REQUIRE(CanStandardId(0x7FF) == 0x7FF);
+}
+
+TEST_CASE ("Verify capping of CAN IDs exceeding 11-Bit CAN ID range", "[CanMsg-CanStandardId-03]")
+{
+  REQUIRE(CanStandardId(0x800U)      == 0x000U);
+  REQUIRE(CanStandardId(0x801U)      == 0x001U);
+  REQUIRE(CanStandardId(0x8FFU)      == 0x0FFU);
+  REQUIRE(CanStandardId(0x1FFFFFFFU) == 0x7FFU);
+  REQUIRE(CanStandardId(0xFFFFFFFFU) == 0x7FFU);
+}

--- a/test/src/CanMsg/test_isExtendedId.cpp
+++ b/test/src/CanMsg/test_isExtendedId.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Arduino.  All rights reserved.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <catch.hpp>
+
+#include <CanMsg.h>
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+using namespace arduino;
+
+/**************************************************************************************
+ * TEST CODE
+ **************************************************************************************/
+
+TEST_CASE ("\"isExtendedId\" should return true for extended CAN ID", "[CanMsg-isExtendedId-01]")
+{
+  CanMsg const msg_ext_id(CanExtendedId(0x020), 0, nullptr);
+  REQUIRE(msg_ext_id.isExtendedId() == true);
+}
+
+TEST_CASE ("\"isExtendedId\" should return false for standard CAN ID", "[CanMsg-isExtendedId-02]")
+{
+  CanMsg const msg_std_id(CanStandardId(0x020), 0, nullptr);
+  REQUIRE(msg_std_id.isExtendedId() == false);
+}

--- a/test/src/CanMsg/test_isStandardId.cpp
+++ b/test/src/CanMsg/test_isStandardId.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Arduino.  All rights reserved.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <catch.hpp>
+
+#include <CanMsg.h>
+
+/**************************************************************************************
+ * NAMESPACE
+ **************************************************************************************/
+
+using namespace arduino;
+
+/**************************************************************************************
+ * TEST CODE
+ **************************************************************************************/
+
+TEST_CASE ("\"isStandardId\" should return true for standard CAN ID", "[CanMsg-isStandardId-01]")
+{
+  CanMsg const msg_std_id(CanStandardId(0x020), 0, nullptr);
+  REQUIRE(msg_std_id.isStandardId() == true);
+}
+
+TEST_CASE ("\"isStandardId\" should return false for extended CAN ID", "[CanMsg-isStandardId-02]")
+{
+  CanMsg const msg_ext_id(CanExtendedId(0x020), 0, nullptr);
+  REQUIRE(msg_ext_id.isStandardId() == false);
+}

--- a/test/src/CanMsg/test_operator_assignment.cpp
+++ b/test/src/CanMsg/test_operator_assignment.cpp
@@ -20,12 +20,14 @@ using namespace arduino;
  * TEST CODE
  **************************************************************************************/
 
-TEST_CASE ("Test copy constructor", "[CanMsg-CopyCtor-01]")
+TEST_CASE ("Testing CanMsg::operator = (CanMsg const &)", "[CanMsg-Operator-=-1]")
 {
   uint8_t const msg_data[4] = {0xDE, 0xAD, 0xC0, 0xDE};
 
   CanMsg const msg_1(CanStandardId(0x20), sizeof(msg_data), msg_data);
-  CanMsg const msg_2(msg_1);
+  CanMsg msg_2(CanStandardId(0x21), 0, nullptr);
+
+  msg_2 = msg_1;
 
   REQUIRE(msg_1.data_length == msg_2.data_length);
 

--- a/test/src/CanMsg/test_printTo.cpp
+++ b/test/src/CanMsg/test_printTo.cpp
@@ -32,7 +32,7 @@ TEST_CASE ("Print CAN frame with standard ID", "[CanMsg-printTo-1]")
   REQUIRE(mock._str  == "[020] (2) : BEEF");
 }
 
-TEST_CASE ("Print CAN frame with extended ID", "[CanMsg-printTo-1]")
+TEST_CASE ("Print CAN frame with extended ID", "[CanMsg-printTo-2]")
 {
   uint8_t const ext_msg_data[] = {0xDE, 0xAD, 0xC0, 0xDE};
   CanMsg const ext_msg(CanExtendedId(0x20), sizeof(ext_msg_data), ext_msg_data);

--- a/test/src/CanMsg/test_printTo.cpp
+++ b/test/src/CanMsg/test_printTo.cpp
@@ -9,6 +9,7 @@
 #include <catch.hpp>
 
 #include <CanMsg.h>
+#include <PrintMock.h>
 
 /**************************************************************************************
  * NAMESPACE
@@ -20,18 +21,24 @@ using namespace arduino;
  * TEST CODE
  **************************************************************************************/
 
-TEST_CASE ("Test copy constructor", "[CanMsg-CopyCtor-01]")
+TEST_CASE ("Print CAN frame with standard ID", "[CanMsg-printTo-1]")
 {
-  uint8_t const msg_data[4] = {0xDE, 0xAD, 0xC0, 0xDE};
+  uint8_t const std_msg_data[] = {0xBE, 0xEF};
+  CanMsg const std_msg(CanStandardId(0x20), sizeof(std_msg_data), std_msg_data);
 
-  CanMsg const msg_1(CanStandardId(0x20), sizeof(msg_data), msg_data);
-  CanMsg const msg_2(msg_1);
+  PrintMock mock;
+  mock.print(std_msg);
 
-  REQUIRE(msg_1.data_length == msg_2.data_length);
+  REQUIRE(mock._str  == "[020] (2) : BEEF");
+}
 
-  for (size_t i = 0; i < msg_1.data_length; i++)
-  {
-    REQUIRE(msg_1.data[i] == msg_data[i]);
-    REQUIRE(msg_2.data[i] == msg_data[i]);
-  }
+TEST_CASE ("Print CAN frame with extended ID", "[CanMsg-printTo-1]")
+{
+  uint8_t const ext_msg_data[] = {0xDE, 0xAD, 0xC0, 0xDE};
+  CanMsg const ext_msg(CanExtendedId(0x20), sizeof(ext_msg_data), ext_msg_data);
+
+  PrintMock mock;
+  mock.print(ext_msg);
+
+  REQUIRE(mock._str  == "[00000020] (4) : DEADC0DE");
 }


### PR DESCRIPTION
… following a <linux/can.h> inspired approach.