### PR TITLE
Fix volatile errors when compiling for C++23

### DIFF
--- a/api/RingBuffer.h
+++ b/api/RingBuffer.h
@@ -77,7 +77,7 @@ void RingBufferN<N>::store_char( uint8_t c )
   {
     _aucBuffer[_iHead] = c ;
     _iHead = nextIndex(_iHead);
-    _numElems++;
+    _numElems = _numElems + 1;
   }
 }
 
@@ -97,7 +97,7 @@ int RingBufferN<N>::read_char()
 
   uint8_t value = _aucBuffer[_iTail];
   _iTail = nextIndex(_iTail);
-  _numElems--;
+  _numElems = _numElems - 1;
 
   return value;
 }


### PR DESCRIPTION
C++20 deprecated the use of increment/decrement with volatile variables. This PR avoids the compiler warning at that language level or later.