### PR TITLE
Fix format specifier for printing CAN message ID in CanMsg.h.

### DIFF
--- a/api/CanMsg.h
+++ b/api/CanMsg.h
@@ -12,7 +12,7 @@
  * INCLUDE
  **************************************************************************************/
 
-#include <stdint.h>
+#include <inttypes.h>
 #include <string.h>
 
 #include <Arduino.h>
@@ -68,7 +68,7 @@ public:
     size_t len = 0;
 
     /* Print the header. */
-    len = snprintf(buf, sizeof(buf), "[%08X] (%d) : ", id, data_length);
+    len = snprintf(buf, sizeof(buf), "[%08" PRIX32 "] (%d) : ", id, data_length);
     size_t n = p.write(buf, len);
 
     /* Print the data. */


### PR DESCRIPTION
Reproducible with an empty sketch:

```
// my_example.ino

void setup()
{
}

void loop()
{
}
```

Compiled with:

```
arduino-cli compile --build-property compiler.cpp.extra_flags='-Wno-unused-parameter -Werror' --fqbn arduino:mbed_nano:nano33ble --log-level trace --verbose --warnings all my_example/my_example.ino
```

Tail of the output:

```
In file included from /home/hroche/.arduino15/packages/arduino/hardware/mbed_nano/4.0.4/cores/arduino/api/CanMsgRingbuffer.h:17:0,
                 from /home/hroche/.arduino15/packages/arduino/hardware/mbed_nano/4.0.4/cores/arduino/api/CanMsgRingbuffer.cpp:12:
/home/hroche/.arduino15/packages/arduino/hardware/mbed_nano/4.0.4/cores/arduino/api/CanMsg.h: In member function 'virtual size_t arduino::CanMsg::printTo(arduino::Print&) const':
/home/hroche/.arduino15/packages/arduino/hardware/mbed_nano/4.0.4/cores/arduino/api/CanMsg.h:71:71: error: format '%X' expects argument of type 'unsigned int', but argument 4 has type 'uint32_t {aka long unsigned int}' [-Werror=format=]
     len = snprintf(buf, sizeof(buf), "[%08X] (%d) : ", id, data_length);
                                                        ~~             ^
cc1plus: all warnings being treated as errors


Used platform     Version Path                                                             
arduino:mbed_nano 4.0.4   /home/hroche/.arduino15/packages/arduino/hardware/mbed_nano/4.0.4
Error during build: exit status
```