### PR TITLE
Fixed string::replace doesn't replace multiple occurrences of longer string with shorter one 

### DIFF
--- a/api/String.cpp
+++ b/api/String.cpp
@@ -652,7 +652,7 @@ void String::replace(const String& find, const String& replace)
 		}
 	} else if (diff < 0) {
 		unsigned int size = len; // compute size needed for result
-        diff = 0 - diff;
+		diff = 0 - diff;
 		while ((foundAt = strstr(readFrom, find.buffer)) != NULL) {
 			readFrom = foundAt + find.len;
 			size -= diff;

--- a/api/String.cpp
+++ b/api/String.cpp
@@ -234,10 +234,10 @@ void String::move(String &rhs)
 String & String::operator = (const String &rhs)
 {
 	if (this == &rhs) return *this;
-	
+
 	if (rhs.buffer) copy(rhs.buffer, rhs.len);
 	else invalidate();
-	
+
 	return *this;
 }
 
@@ -253,7 +253,7 @@ String & String::operator = (const char *cstr)
 {
 	if (cstr) copy(cstr, strlen(cstr));
 	else invalidate();
-	
+
 	return *this;
 }
 
@@ -484,7 +484,7 @@ bool String::equalsIgnoreCase( const String &s2 ) const
 	const char *p2 = s2.buffer;
 	while (*p1) {
 		if (tolower(*p1++) != tolower(*p2++)) return false;
-	} 
+	}
 	return true;
 }
 
@@ -515,7 +515,7 @@ char String::charAt(unsigned int loc) const
 	return operator[](loc);
 }
 
-void String::setCharAt(unsigned int loc, char c) 
+void String::setCharAt(unsigned int loc, char c)
 {
 	if (loc < len) buffer[loc] = c;
 }
@@ -652,9 +652,9 @@ void String::replace(const String& find, const String& replace)
 		}
 	} else if (diff < 0) {
 		unsigned int size = len; // compute size needed for result
+        diff = 0 - diff;
 		while ((foundAt = strstr(readFrom, find.buffer)) != NULL) {
 			readFrom = foundAt + find.len;
-			diff = 0 - diff;
 			size -= diff;
 		}
 		if (size == len) return;

--- a/test/src/String/test_replace.cpp
+++ b/test/src/String/test_replace.cpp
@@ -66,3 +66,24 @@ TEST_CASE ("Testing String::replace(String, String) substr 'find' smaller than '
   str.replace(arduino::String("ll"), arduino::String("111"));
   REQUIRE(str == "He111o Arduino!");
 }
+
+TEST_CASE ("Testing String::replace(String, String) substr 'find' smaller than 'replace' multiple occurencies", "[String-replace-08]")
+{
+  arduino::String str("Hello Arduino! Hello, Hello, Hello");
+  str.replace(arduino::String("ll"), arduino::String("lll"));
+  REQUIRE(str == "Helllo Arduino! Helllo, Helllo, Helllo");
+}
+
+TEST_CASE ("Testing String::replace(String, String) substr 'find' same length as 'replace' multiple occurencies", "[String-replace-09]")
+{
+  arduino::String str("Hello Arduino! Hello, Hello, Hello");
+  str.replace(arduino::String("ll"), arduino::String("11"));
+  REQUIRE(str == "He11o Arduino! He11o, He11o, He11o");
+}
+
+TEST_CASE ("Testing String::replace(String, String) substr 'find' larger than 'replace' multiple occurencies", "[String-replace-10]")
+{
+  arduino::String str("Helllo Arduino! Helllo, Helllo, Helllo");
+  str.replace(arduino::String("lll"), arduino::String("ll"));
+  REQUIRE(str == "Hello Arduino! Hello, Hello, Hello");
+}


### PR DESCRIPTION
This pr fixes `string::replace` not replacing multiple occurrences of longer string with shorter one.
I also included unit tests from the issue

This fixes #199