### PR TITLE
Fix: add test case for CanMsgRingBuffer.

### DIFF
--- a/api/CanMsgRingbuffer.cpp
+++ b/api/CanMsgRingbuffer.cpp
@@ -40,7 +40,7 @@ void CanMsgRingbuffer::enqueue(CanMsg const & msg)
 
   _buf[_head] = msg;
   _head = next(_head);
-  _num_elems++;
+  _num_elems = _num_elems + 1;
 }
 
 CanMsg CanMsgRingbuffer::dequeue()
@@ -50,7 +50,7 @@ CanMsg CanMsgRingbuffer::dequeue()
 
   CanMsg const msg = _buf[_tail];
   _tail = next(_tail);
-  _num_elems--;
+  _num_elems = _num_elems - 1;
 
   return msg;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ set(TEST_SRCS
   src/CanMsg/test_isStandardId.cpp
   src/CanMsg/test_operator_assignment.cpp
   src/CanMsg/test_printTo.cpp
+  src/CanMsgRingbuffer/test_available.cpp
   src/Common/test_makeWord.cpp
   src/Common/test_map.cpp
   src/Common/test_max.cpp
@@ -104,6 +105,7 @@ set(TEST_SRCS
 
 set(TEST_DUT_SRCS
   ../api/CanMsg.cpp
+  ../api/CanMsgRingbuffer.cpp
   ../api/Common.cpp
   ../api/IPAddress.cpp
   ../api/String.cpp

--- a/test/src/CanMsgRingbuffer/test_available.cpp
+++ b/test/src/CanMsgRingbuffer/test_available.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020 Arduino.  All rights reserved.
+ */
+
+/**************************************************************************************
+ * INCLUDE
+ **************************************************************************************/
+
+#include <catch.hpp>
+
+#include <CanMsgRingbuffer.h>
+
+/**************************************************************************************
+ * TEST CODE
+ **************************************************************************************/
+
+TEST_CASE ("'available' should return 0 for empty CanMsg ring buffer", "[CanMsgRingbuffer-available-01]")
+{
+  arduino::CanMsgRingbuffer ringbuffer;
+  REQUIRE(ringbuffer.available() == 0);
+}
+
+TEST_CASE ("'available' should return number of elements in CanMsg ringbuffer", "[CanMsgRingbuffer-available-02]")
+{
+  arduino::CanMsgRingbuffer ringbuffer;
+  arduino::CanMsg msg;
+  ringbuffer.enqueue(msg);
+  REQUIRE(ringbuffer.available() == 1);
+  ringbuffer.enqueue(msg);
+  REQUIRE(ringbuffer.available() == 2);
+  ringbuffer.dequeue();
+  REQUIRE(ringbuffer.available() == 1);
+}


### PR DESCRIPTION
Fixes a deprecated use of volatile in CanMsgRingbuffer.
Also added a basic testcase to make sure the CPP file is compiled/tested.

Relies on PR #206 to reliably run the tests under C++20