### PR TITLE
Replace use of deprecated sprintf in IPAddress

### DIFF
--- a/api/IPAddress.cpp
+++ b/api/IPAddress.cpp
@@ -96,26 +96,20 @@ IPAddress::IPAddress(const char *address)
 
 String IPAddress::toString4() const
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     char szRet[16];
-    sprintf(szRet,"%u.%u.%u.%u", _address.bytes[IPADDRESS_V4_BYTES_INDEX], _address.bytes[IPADDRESS_V4_BYTES_INDEX + 1], _address.bytes[IPADDRESS_V4_BYTES_INDEX + 2], _address.bytes[IPADDRESS_V4_BYTES_INDEX + 3]);
+    snprintf(szRet, sizeof(szRet), "%u.%u.%u.%u", _address.bytes[IPADDRESS_V4_BYTES_INDEX], _address.bytes[IPADDRESS_V4_BYTES_INDEX + 1], _address.bytes[IPADDRESS_V4_BYTES_INDEX + 2], _address.bytes[IPADDRESS_V4_BYTES_INDEX + 3]);
     return String(szRet);
-#pragma GCC diagnostic pop
 }
 
 String IPAddress::toString6() const
 {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     char szRet[40];
-    sprintf(szRet,"%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
+    snprintf(szRet, sizeof(szRet), "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
             _address.bytes[0], _address.bytes[1], _address.bytes[2], _address.bytes[3],
             _address.bytes[4], _address.bytes[5], _address.bytes[6], _address.bytes[7],
             _address.bytes[8], _address.bytes[9], _address.bytes[10], _address.bytes[11],
             _address.bytes[12], _address.bytes[13], _address.bytes[14], _address.bytes[15]);
     return String(szRet);
-#pragma GCC diagnostic pop
 }
 
 String IPAddress::toString() const


### PR DESCRIPTION
Partial fix for #209 by replacing use of `sprintf` with `snprintf`
Remove warning suppression  added in #208 