### PR TITLE
Remove guards as we already require C++11

### DIFF
--- a/api/String.cpp
+++ b/api/String.cpp
@@ -63,7 +63,6 @@ String::String(const __FlashStringHelper *pstr)
 	*this = pstr;
 }
 
-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 String::String(String &&rval)
 	: buffer(rval.buffer)
 	, capacity(rval.capacity)
@@ -73,7 +72,6 @@ String::String(String &&rval)
 	rval.capacity = 0;
 	rval.len = 0;
 }
-#endif
 
 String::String(char c)
 {
@@ -213,7 +211,6 @@ String & String::copy(const __FlashStringHelper *pstr, unsigned int length)
 	return *this;
 }
 
-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 void String::move(String &rhs)
 {
 	if (this != &rhs)
@@ -229,7 +226,6 @@ void String::move(String &rhs)
 		rhs.capacity = 0;
 	}
 }
-#endif
 
 String & String::operator = (const String &rhs)
 {
@@ -241,13 +237,11 @@ String & String::operator = (const String &rhs)
 	return *this;
 }
 
-#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 String & String::operator = (String &&rval)
 {
 	move(rval);
 	return *this;
 }
-#endif
 
 String & String::operator = (const char *cstr)
 {

--- a/api/String.h
+++ b/api/String.h
@@ -72,9 +72,7 @@ public:
 	String(const uint8_t *cstr, unsigned int length) : String((const char*)cstr, length) {}
 	String(const String &str);
 	String(const __FlashStringHelper *str);
-	#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 	String(String &&rval);
-	#endif
 	explicit String(char c);
 	explicit String(unsigned char, unsigned char base=10);
 	explicit String(int, unsigned char base=10);
@@ -98,9 +96,7 @@ public:
 	String & operator = (const String &rhs);
 	String & operator = (const char *cstr);
 	String & operator = (const __FlashStringHelper *str);
-	#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 	String & operator = (String &&rval);
-	#endif
 
 	// concatenate (works w/ built-in types)
 
@@ -231,9 +227,7 @@ protected:
 	// copy and move
 	String & copy(const char *cstr, unsigned int length);
 	String & copy(const __FlashStringHelper *pstr, unsigned int length);
-	#if __cplusplus >= 201103L || defined(__GXX_EXPERIMENTAL_CXX0X__)
 	void move(String &rhs);
-	#endif
 };
 
 class StringSumHelper : public String


### PR DESCRIPTION
There are some legacy guards around the availability of C++11 features. However, we already require that version _in this file_ as well as others so they can be removed.