### PR TITLE
Document that C++11 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ In order to compile a core which is implementing ArduinoCore-API you'll need to 
 tar --exclude='*.git*' -cjhvf $yourcore-$version.tar.bz2 $yourcore/
 ```
 
+The API is coded to the C++11 standard and the core's compiler must be able to support that version of the language.
+
 Documentation for how to integrate with a Arduino core (which is necessary if you do not download the Arduino core via the Boards Manager) can be found here:
 * [ArduinoCore-megaavr](https://github.com/arduino/ArduinoCore-megaavr#developing)
 * [ArduinoCore-mbed](https://github.com/arduino/ArduinoCore-mbed#clone-the-repository-in-sketchbookhardwarearduino-git)


### PR DESCRIPTION
After the discussion in #213, I thought it would be helpful to state in the documentation the version of the language that a core needs to support in order to use the API. It also makes it clearer to contributors which language level they must stick to.