### PR TITLE
Fix #217 when compiling with newer compiler versions

### DIFF
--- a/api/CanMsg.h
+++ b/api/CanMsg.h
@@ -51,12 +51,7 @@ public:
 
   CanMsg() : CanMsg(0, 0, nullptr) { }
 
-  CanMsg(CanMsg const & other)
-  {
-    this->id          = other.id;
-    this->data_length = other.data_length;
-    if (this->data_length && other.data)
-      memcpy(this->data, other.data, this->data_length);
+  CanMsg(CanMsg const & other) : CanMsg(other.id, other.data_length, other.data) {
   }
 
   virtual ~CanMsg() { }
@@ -65,10 +60,10 @@ public:
   {
     if (this != &other)
     {
-      this->id          = other.id;
-      this->data_length = other.data_length;
-      if (this->data_length && other.data)
-        memcpy(this->data, other.data, this->data_length);
+      id          = other.id;
+      data_length = other.data_length;
+      if (data_length > 0)
+        memcpy(data, other.data, data_length);
     }
     return (*this);
   }

--- a/api/CanMsg.h
+++ b/api/CanMsg.h
@@ -51,7 +51,11 @@ public:
 
   CanMsg() : CanMsg(0, 0, nullptr) { }
 
-  CanMsg(CanMsg const & other) : CanMsg(other.id, other.data_length, other.data) {
+  CanMsg(CanMsg const & other) {
+      id          = other.id;
+      data_length = other.data_length;
+      if (data_length > 0)
+          memcpy(data, other.data, data_length);
   }
 
   virtual ~CanMsg() { }

--- a/api/CanMsg.h
+++ b/api/CanMsg.h
@@ -51,11 +51,12 @@ public:
 
   CanMsg() : CanMsg(0, 0, nullptr) { }
 
-  CanMsg(CanMsg const & other) {
-      id          = other.id;
-      data_length = other.data_length;
-      if (data_length > 0)
-          memcpy(data, other.data, data_length);
+  CanMsg(CanMsg const & other)
+  {
+    id          = other.id;
+    data_length = other.data_length;
+    if (data_length > 0)
+      memcpy(data, other.data, data_length);
   }
 
   virtual ~CanMsg() { }


### PR DESCRIPTION
`other.data` will never be null, triggering a compilation error with the test cases on GCC-13 or CLang 15.0.0