### PR TITLE
Rewrite IPAddress without union

### DIFF
--- a/api/IPAddress.h
+++ b/api/IPAddress.h
@@ -19,12 +19,12 @@
 
 #pragma once
 
+#include <array>
 #include <stdint.h>
 #include "Printable.h"
 #include "String.h"
 
 #define IPADDRESS_V4_BYTES_INDEX 12
-#define IPADDRESS_V4_DWORD_INDEX 3
 
 // forward declarations of global name space friend classes
 class EthernetClass;
@@ -42,17 +42,14 @@ enum IPType {
 
 class IPAddress : public Printable {
 private:
-    union {
-        uint8_t bytes[16];
-        uint32_t dword[4];
-    } _address;
-    IPType _type;
+    alignas(alignof(uint32_t)) std::array<uint8_t, 16> _address{};
+    IPType _type{IPv4};
 
     // Access the raw byte array containing the address.  Because this returns a pointer
     // to the internal structure rather than a copy of the address this function should only
     // be used when you know that the usage of the returned uint8_t* will be transient and not
     // stored.
-    uint8_t* raw_address() { return _type == IPv4 ? &_address.bytes[IPADDRESS_V4_BYTES_INDEX] : _address.bytes; }
+    uint8_t* raw_address() { return _type == IPv4 ? &_address[IPADDRESS_V4_BYTES_INDEX] : _address.data(); }
 
 public:
     // Constructors
@@ -75,7 +72,7 @@ public:
 
     // Overloaded cast operator to allow IPAddress objects to be used where a uint32_t is expected
     // NOTE: IPv4 only; see implementation note
-    operator uint32_t() const { return _type == IPv4 ? _address.dword[IPADDRESS_V4_DWORD_INDEX] : 0; };
+    operator uint32_t() const { return _type == IPv4 ? *reinterpret_cast<const uint32_t*>(&_address[IPADDRESS_V4_BYTES_INDEX]) : 0; };
 
     bool operator==(const IPAddress& addr) const;
     bool operator!=(const IPAddress& addr) const { return !(*this == addr); };


### PR DESCRIPTION
## Rewrite IPAddress without union

Using a union allowed undefined behavior for 8-bit integer INPUT and OUTPUT arguments through a 32-bit integer (and vice versa). Write throught union::uint8_t[16] and read thoutght union::uint32_t[4] is a undefined behavior.

C++ standard says (https://timsong-cpp.github.io/cppwp/n4659/class.union#1): "At most one of the non-static data members of an object of union type can be active at any time, that is, the value of at most one of the non-static data members can be stored in a union at any time. [ Note: One special guarantee is made in order to simplify the use of unions: If a standard-layout union contains several standard-layout structs that share a common initial sequence, and if a non-static data member of an object of this standard-layout union type is active and is one of the standard-layout structs, it is permitted to inspect the common initial sequence of any of the standard-layout struct members; see [class.mem].  — end note ]"

and (https://timsong-cpp.github.io/cppwp/n4659/class.mem#22): "Two standard-layout unions are layout-compatible if they have the same number of non-static data members and corresponding non-static data members (in any order) have layout-compatible types."

you can't hope that compilers don't seem to do undefined behavior at the moment

Also created https://github.com/espressif/arduino-esp32/pull/8829 PR dependent on changing the current API.