### PR TITLE
Adding UNDEFINED pin status

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -9,11 +9,12 @@ extern "C"{
 void yield(void);
 
 typedef enum {
-  LOW     = 0,
-  HIGH    = 1,
-  CHANGE  = 2,
-  FALLING = 3,
-  RISING  = 4,
+  LOW       = 0,
+  HIGH      = 1,
+  CHANGE    = 2,
+  FALLING   = 3,
+  RISING    = 4,
+  UNDEFINED = 5,
 } PinStatus;
 
 typedef enum {


### PR DESCRIPTION
I'm new to Arduino and as an exercise I'm working on a class encapsulating a digital input. The corresponding `read()` method returns a `PinStatus`. Normally it is `LOW` or `HIGH`, but an `UNDEFINED` status is usefull if the corresponding object has not yet been initialised (i.e. the `init()` method has not been called, which in turn calls `pinMode(INPUT)`).