### PR TITLE
Stream - new virtual method `clear()` to clear the receive buffer

### DIFF
--- a/api/Stream.cpp
+++ b/api/Stream.cpp
@@ -86,6 +86,11 @@ int Stream::peekNextDigit(LookaheadMode lookahead, bool detectDecimal)
 // Public Methods
 //////////////////////////////////////////////////////////////
 
+void Stream::clear() {
+  while (available())
+    read();
+}
+
 void Stream::setTimeout(unsigned long timeout)  // sets the maximum number of milliseconds to wait
 {
   _timeout = timeout;

--- a/api/Stream.h
+++ b/api/Stream.h
@@ -61,6 +61,8 @@ class Stream : public Print
     virtual int read() = 0;
     virtual int peek() = 0;
 
+    virtual void clear(); // clears the receive buffer
+
     Stream() {_timeout=1000;}
 
 // parsing methods


### PR DESCRIPTION
A very long time ago, in Arduino, `flush()` changed from "purge input" to "send output buffer" and moved from Stream to Print.
But now there is no method to "purge input" and there is demand as I see it on forums.

Arduino classes and methods are inspired by the Processing language. Processing has `Stream.clear()`.

**The goal of this PR is to establish the name `clear` for  "purge input" functions in Stream implementations.**

For backward compatibility the method can not be added as pure virtual so some implementation has to be provided. An empty implementation would be confusing, so I took the `flush()` implementation from Arduino 0023 Ethernet library's Client class.