### PR TITLE
Fix spell check false positive by ignoring word

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = hel
+ignore-words-list = hel,shiftin
 check-filenames =
 check-hidden =
 skip = ./.git,./test/external


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) spellchecker tool is used to automatically detect commonly misspelled words in the files of this project.

The misspelled words dictionary was expanded in the [latest release](https://github.com/codespell-project/codespell/releases/tag/v2.3.0) of codespell. Some of the text in the project codebase happens to match against newly added entries, which caused **codespell** to produce a false misspelled word detection:

https://github.com/arduino/ArduinoCore-API/actions/runs/9265748213

>[spellcheck: api/Common.h#L111](https://github.com/arduino/ArduinoCore-API/commit/331cdd9ad216941cc2dedefa51fe643d1c4f0ac2#annotation_22105396533)
shiftIn ==> shifting, shift in

Since the code that produced the detection is correct and intended, the false positive is resolved by [configuring](https://github.com/codespell-project/codespell#using-a-config-file) **codespell** to ignore the problematic word.

