### PR TITLE
Move analogReference enum to ArduinoCore-API

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -29,6 +29,15 @@ typedef enum {
   MSBFIRST = 1,
 } BitOrder;
 
+typedef enum {
+  AR_DEFAULT,
+  AR_INTERNAL,
+  AR_EXTERNAL,
+  AR_INTERNAL1V0,
+  AR_INTERNAL1V65,
+  AR_INTERNAL2V23
+} AnalogReference;
+
 #define PI          3.1415926535897932384626433832795
 #define HALF_PI     1.5707963267948966192313216916398
 #define TWO_PI      6.283185307179586476925286766559
@@ -97,7 +106,7 @@ void pinMode(pin_size_t pinNumber, PinMode pinMode);
 void digitalWrite(pin_size_t pinNumber, PinStatus status);
 PinStatus digitalRead(pin_size_t pinNumber);
 int analogRead(pin_size_t pinNumber);
-void analogReference(uint8_t mode);
+void analogReference(AnalogReference mode);
 void analogWrite(pin_size_t pinNumber, int value);
 
 unsigned long millis(void);


### PR DESCRIPTION
Currently, the header for `analogReference(...)` is in ArduinoCore-API and takes `uint8_t` as argument type. 

The implementation of that function is in ArduinoCore-samd ([here](https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/wiring_analog.c#L94)), but takes `eAnalogReference` enum as argument type. The enum is defined in [Arduino.h](https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/Arduino.h#L79-L87)

Compiling `ArduinoCore-samd/cores/arduino/wiring_analog.c` will give a warning:

```
[ 31%] Building C object .../ArduinoCore-samd/cores/arduino/wiring_analog.c.obj
/home/.../ArduinoCore-samd/cores/arduino/wiring_analog.c:94:6: warning: conflicting types for 'analogReference' due to enum/integer mismatch; have 'void(eAnalogReference)' {aka 'void(enum _eAnalogReference)'} [-Wenum-int-mismatch]
   94 | void analogReference(eAnalogReference mode)
      |      ^~~~~~~~~~~~~~~
In file included from /home/.../ArduinoCore-API/api/ArduinoAPI.h:50,
                 from /home/.../ArduinoCore-samd/cores/arduino/Arduino.h:23,
                 from /home/.../ArduinoCore-samd/cores/arduino/wiring_analog.c:19:
/home/.../ArduinoCore-API/api/Common.h:100:6: note: previous declaration of 'analogReference' with type 'void(uint8_t)' {aka 'void(unsigned char)'}
  100 | void analogReference(uint8_t mode);
      |      ^~~~~~~~~~~~~~~
```

My proposal is to move that enum from Arduino.h in ArduinoCore-samd fully into ArduinoCore-API. Seems cleaner to me.

I filed a corresponding PR in ArduinoCore-samd too: 
https://github.com/arduino/ArduinoCore-samd/pull/718
