### PR TITLE
Remove donation links from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ Documentation for how to integrate with a Arduino core (which is necessary if yo
 * [ArduinoCore-mbed](https://github.com/arduino/ArduinoCore-mbed#clone-the-repository-in-sketchbookhardwarearduino-git)
 * [ArduinoCore-samd](https://github.com/arduino/ArduinoCore-samd/#developing)
 
-## Donations
+## Support the project
 
-This open source code is maintained by Arduino with the help of the community. We invest a considerable amount of time in testing code, optimizing it and introducing new features. Please consider [donating](https://www.arduino.cc/en/donate/) or [sponsoring](https://github.com/sponsors/arduino) to support our work, as well as [buying original Arduino boards](https://store.arduino.cc) which is the best way to make sure our effort can continue in the long term.
+This open source code is maintained by Arduino with the help of the community. We invest a considerable amount of time in testing code, optimizing it and introducing new features. Please consider [buying original Arduino boards](https://store.arduino.cc) to support our work on the project.
 
 ## License and credits
 


### PR DESCRIPTION
The Arduino company is no longer soliciting monetary donations. Community members who wish to contribute to the project still have opportunities to do so via the other options listed under the "Contributions" section of the readme.

Those who wish to make a monetary contribution can still do so by purchasing official Arduino products. For this reason, that part of the donation request text is preserved. Since the "Donations" heading doesn't make sense after the removal of the context of other monetary contribution options, the heading is hereby changed to "Support the project".