### PR TITLE
fix(HardwareSPI): make SPISettings constructors constexpr

### DIFF
--- a/api/HardwareSPI.h
+++ b/api/HardwareSPI.h
@@ -45,24 +45,25 @@ typedef enum {
 
 class SPISettings {
   public:
-  SPISettings(uint32_t clock, BitOrder bitOrder, SPIMode dataMode, SPIBusMode busMode = SPI_CONTROLLER) {
-    if (__builtin_constant_p(clock)) {
-      init_AlwaysInline(clock, bitOrder, dataMode, busMode);
-    } else {
-      init_MightInline(clock, bitOrder, dataMode, busMode);
-    }
-  }
-
-  SPISettings(uint32_t clock, BitOrder bitOrder, int dataMode, SPIBusMode busMode = SPI_CONTROLLER) {
-    if (__builtin_constant_p(clock)) {
-      init_AlwaysInline(clock, bitOrder, (SPIMode)dataMode, busMode);
-    } else {
-      init_MightInline(clock, bitOrder, (SPIMode)dataMode, busMode);
-    }
-  }
-
+  constexpr SPISettings(uint32_t clock, BitOrder bitOrder, SPIMode dataMode, SPIBusMode busMode = SPI_CONTROLLER)
+    : clockFreq(clock),
+      dataMode(dataMode),
+      bitOrder(bitOrder),
+      busMode(busMode)
+  { }
+    constexpr SPISettings(uint32_t clock, BitOrder bitOrder, int dataMode, SPIBusMode busMode = SPI_CONTROLLER)
+    : clockFreq(clock),
+      dataMode((SPIMode)dataMode),
+      bitOrder(bitOrder),
+      busMode(busMode)
+  { }
   // Default speed set to 4MHz, SPI mode set to MODE 0 and Bit order set to MSB first.
-  SPISettings() { init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0, SPI_CONTROLLER); }
+  constexpr SPISettings()
+    : clockFreq(4000000),
+      dataMode(SPI_MODE0),
+      bitOrder(MSBFIRST),
+      busMode(SPI_CONTROLLER)
+  { }
 
   bool operator==(const SPISettings& rhs) const
   {
@@ -94,18 +95,6 @@ class SPISettings {
   }
 
   private:
-  void init_MightInline(uint32_t clock, BitOrder bitOrder, SPIMode dataMode, SPIBusMode busMode) {
-    init_AlwaysInline(clock, bitOrder, dataMode, busMode);
-  }
-
-  // Core developer MUST use an helper function in beginTransaction() to use this data
-  void init_AlwaysInline(uint32_t clock, BitOrder bitOrder, SPIMode dataMode, SPIBusMode busMode) __attribute__((__always_inline__)) {
-    this->clockFreq = clock;
-    this->dataMode = dataMode;
-    this->bitOrder = bitOrder;
-    this->busMode = busMode;
-  }
-
   uint32_t clockFreq;
   SPIMode dataMode;
   BitOrder bitOrder;


### PR DESCRIPTION
## Summary

This PR makes the `SPISettings` constructors `constexpr` by removing the helper-based runtime initialization (`init_AlwaysInline` / `init_MightInline`) and directly initializing the stored members.

This change is being upstreamed from the STM32 core, where the same issue was already observed, fixed, and validated in practice.

Refs:
- stm32duino/Arduino_Core_STM32#2201
- stm32duino/Arduino_Core_STM32#2204

---

## Why `constexpr` matters here

Even if constructor arguments are compile-time constants, that alone does not guarantee that a global object is constant-initialized.

Without a `constexpr` constructor, a global `SPISettings` object may still require dynamic initialization, which means:
- its final value may not yet be available during early startup,
- another global object from a different translation unit may observe it too early,
- behavior can differ between a temporary `SPISettings(...)` and a global/static `SPISettings`.

Making the constructors `constexpr` restores the expected constant-initialization behavior when possible.

---

## Why this belongs in ArduinoCore-API

At the API layer, `SPISettings` is a value object storing SPI configuration:
- clock frequency
- data mode
- bit order
- bus mode

The API layer does not need target-specific helper patterns such as `always_inline` / `mightInline`. Those are implementation/codegen details and are better left to core-specific implementations.

Direct member initialization in `constexpr` constructors keeps the API simple and restores safe initialization semantics.

---

## Validation


To demonstrate the initialization issue directly, I also reproduced the same semantic problem on Arduino Uno with an equivalent AVR-side test using the real `SPISettings` type.

Note: Arduino Uno does not use api/HardwareSPI.h directly. The Uno test below is an equivalent reproducer of the same initialization-semantics issue, used to demonstrate why constexpr matters for global/static SPISettings objects.

### Reproducer sketch

```cpp
#include <Arduino.h>
#include <SPI.h>
#include <string.h>

SPISettings globalSpiSettings;

uint8_t bytesBefore[sizeof(SPISettings)];  // raw bytes captured before global constructors

extern "C" void copyBeforeConstructors(void) __attribute__((used, noinline));
extern "C" void copyBeforeConstructors(void) {
  memcpy(bytesBefore, &globalSpiSettings, sizeof(bytesBefore));
}

extern "C" void runBeforeConstructors(void)
    __attribute__((naked, used, section(".init5")));  // run after memory init (.init4), before global C++ constructors (.init6)

extern "C" void runBeforeConstructors(void) {
  asm volatile("call copyBeforeConstructors");
}

void setup() {
  Serial.begin(115200);
  delay(1000);

  uint8_t bytesAfter[sizeof(SPISettings)];
  memcpy(bytesAfter, &globalSpiSettings, sizeof(bytesAfter));

  Serial.print("before: ");
  for (size_t i = 0; i < sizeof(bytesBefore); ++i) {
    if (i) Serial.print(' ');
    if (bytesBefore[i] < 16) Serial.print('0');
    Serial.print(bytesBefore[i], HEX);
  }
  Serial.println();

  Serial.print("after : ");
  for (size_t i = 0; i < sizeof(bytesAfter); ++i) {
    if (i) Serial.print(' ');
    if (bytesAfter[i] < 16) Serial.print('0');
    Serial.print(bytesAfter[i], HEX);
  }
  Serial.println();
}

void loop() {}
```
and here was the fix that was made to test it on avr SPI.H

```cpp
class SPISettings {
public:
  constexpr SPISettings(uint32_t clock, uint8_t bitOrder, uint8_t dataMode)
    : spcr(makeSPCR(clock, bitOrder, dataMode)),
      spsr(makeSPSR(clock))
  {}

  constexpr SPISettings()
    : spcr(makeSPCR(4000000UL, MSBFIRST, SPI_MODE0)),
      spsr(makeSPSR(4000000UL))
  {}

private:
  static constexpr uint8_t rawClockDiv(uint32_t clock) {
    return (clock >= (F_CPU / 2UL))  ? 0 :
           (clock >= (F_CPU / 4UL))  ? 1 :
           (clock >= (F_CPU / 8UL))  ? 2 :
           (clock >= (F_CPU / 16UL)) ? 3 :
           (clock >= (F_CPU / 32UL)) ? 4 :
           (clock >= (F_CPU / 64UL)) ? 5 :
                                        6;
  }

  static constexpr uint8_t packedClockDiv(uint32_t clock) {
    return fixupClockDiv(rawClockDiv(clock));
  }

  static constexpr uint8_t fixupClockDiv(uint8_t clockDiv) {
    return static_cast<uint8_t>(((clockDiv == 6 ? 7 : clockDiv) ^ 0x1));
  }

  static constexpr uint8_t makeSPCR(uint32_t clock, uint8_t bitOrder, uint8_t dataMode) {
    return static_cast<uint8_t>(
      _BV(SPE) |
      _BV(MSTR) |
      ((bitOrder == LSBFIRST) ? _BV(DORD) : 0) |
      (dataMode & SPI_MODE_MASK) |
      ((packedClockDiv(clock) >> 1) & SPI_CLOCK_MASK)
    );
  }

  static constexpr uint8_t makeSPSR(uint32_t clock) {
    return static_cast<uint8_t>(packedClockDiv(clock) & SPI_2XCLOCK_MASK);
  }

  uint8_t spcr;
  uint8_t spsr;
  friend class SPIClass;
};
```


 Uno test results

- without `constexpr`:
  - `before: 00 00`
  - `after : 50 00`

- with `constexpr`:
  - `before: 50 00`
  - `after : 50 00`
