### PR TITLE
feat: extend PinMode enum with INPUT_FLOATING and INPUT_ANALOG

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -36,11 +36,14 @@ typedef enum {
 } PinStatus;
 
 typedef enum {
-  INPUT            = 0x0,
-  OUTPUT           = 0x1,
-  INPUT_PULLUP     = 0x2,
-  INPUT_PULLDOWN   = 0x3,
-  OUTPUT_OPENDRAIN = 0x4,
+  INPUT             = 0x0,
+  OUTPUT            = 0x1,
+  INPUT_PULLUP      = 0x2,
+  INPUT_FLOATING    = INPUT,
+  INPUT_PULLDOWN    = 0x3,
+  OUTPUT_OPENDRAIN  = 0x4,
+  OUTPUT_OPEN_DRAIN = OUTPUT_OPENDRAIN,
+  INPUT_ANALOG      = 0x5,
 } PinMode;
 
 typedef enum {


### PR DESCRIPTION
## Summary

Extend `PinMode` with:
- `INPUT_FLOATING = INPUT`
- `INPUT_ANALOG = 0x5`

Also add:
- `OUTPUT_OPEN_DRAIN = OUTPUT_OPENDRAIN`

## Why

Some cores, especially STM32, expose more explicit GPIO modes than the current common API:
- `INPUT_FLOATING` improves readability and compatibility with existing code, while remaining an alias of `INPUT`
- `INPUT_ANALOG` exposes a real hardware mode available on many MCUs
- `OUTPUT_OPEN_DRAIN` provides a clearer alias for the existing spelling

## Compatibility

This is backward-compatible:
- existing values are unchanged
- aliases do not change behavior
- `INPUT_ANALOG` is additive and only affects code that explicitly uses it

## Benefit

This makes the generic API more expressive and reduces the need for core-specific pin mode constants in sketches and libraries.