### PR TITLE
feat: deprecate boolean typedef in favor of bool

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -93,7 +93,7 @@ typedef void (*voidFuncPtrParam)(void*);
 #endif
 
 /* TODO: request for removal */
-typedef bool      boolean;
+typedef bool      boolean __attribute__((deprecated));
 typedef uint8_t   byte;
 typedef uint16_t  word;
 


### PR DESCRIPTION


## Summary

Deprecate the legacy `boolean` typedef in favor of standard C++ `bool`, while keeping it available for backward compatibility.

## Why

`boolean` is a historical Arduino alias. In modern C++, `bool` is the standard and preferred type.

Marking `boolean` as deprecated:
- preserves compatibility,
- keeps old code building,
- encourages gradual migration

## Compatibility

This is a non-breaking change:
- `boolean` remains available,
- it is still an alias of `bool`,
- existing code should continue to compile,
- users may now see a deprecation warning when using `boolean`.
- 
Ref: arduino#242