### PR TITLE
feat: declare initVariant() as weak

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -98,7 +98,7 @@ typedef uint8_t   byte;
 typedef uint16_t  word;
 
 void init(void);
-void initVariant(void);
+void initVariant(void) __attribute__((weak));
 
 #ifndef HOST
 int atexit(void (*func)()) __attribute__((weak));


### PR DESCRIPTION
## Summary

Declare `initVariant()` as `weak` in `ArduinoCore-API`.

## Why

Some cores provide a default `initVariant()` implementation while allowing variants or boards to override it. Marking the declaration as `weak` makes that extension pattern explicit and consistent at the API level.

## Compatibility

This is backward-compatible:
- existing overrides keep working,
- cores that do not override `initVariant()` are unaffected,
- the change only clarifies the intended linkage behavior.