### PR TITLE
fix: update pulseIn signatures to use pin_size_t

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -175,8 +175,8 @@ uint16_t makeWord(byte h, byte l);
 
 #define word(...) makeWord(__VA_ARGS__)
 
-unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
-unsigned long pulseInLong(uint8_t pin, uint8_t state, unsigned long timeout = 1000000L);
+unsigned long pulseIn(pin_size_t pin, uint8_t state, unsigned long timeout = 1000000L);
+unsigned long pulseInLong(pin_size_t pin, uint8_t state, unsigned long timeout = 1000000L);
 
 void tone(uint8_t _pin, unsigned int frequency, unsigned long duration = 0);
 void noTone(uint8_t _pin);


### PR DESCRIPTION
## Summary

Update `pulseIn()` and `pulseInLong()` to use `pin_size_t` instead of `uint8_t` for the pin argument.

## Why

Other GPIO-related APIs already use `pin_size_t` to represent pin identifiers. Using the same type here improves API consistency and avoids unnecessary narrowing on targets where pin numbers are not limited to 8 bits.

## Compatibility

This is backward-compatible for existing boards using small pin numbers, while improving correctness and portability for cores with larger pin ranges (ex : uint32_t) .