### PR TITLE
feat: enhance Print class with float support and printf functionality

### DIFF
--- a/api/Print.cpp
+++ b/api/Print.cpp
@@ -130,6 +130,11 @@ size_t Print::print(unsigned long long n, int base)
   else return printULLNumber(n, base);
 }
 
+size_t Print::print(float n, int digits)
+{
+  return printFloat(n, digits);
+}
+
 size_t Print::print(double n, int digits)
 {
   return printFloat(n, digits);
@@ -222,6 +227,13 @@ size_t Print::println(unsigned long long num, int base)
   return n;
 }
 
+size_t Print::println(float num, int digits)
+{
+  size_t n = print(num, digits);
+  n += println();
+  return n;
+}
+
 size_t Print::println(double num, int digits)
 {
   size_t n = print(num, digits);
@@ -234,6 +246,34 @@ size_t Print::println(const Printable& x)
   size_t n = print(x);
   n += println();
   return n;
+}
+
+int Print::printf(const char *format, ...)
+{
+  va_list ap;
+  va_start(ap, format);
+  int retval = vdprintf((int)this, format, ap);
+  va_end(ap);
+  return retval;
+}
+
+int Print::printf(const __FlashStringHelper *format, ...)
+{
+  va_list ap;
+  va_start(ap, format);
+  int retval = vdprintf((int)this, (const char *)format, ap);
+  va_end(ap);
+  return retval;
+}
+
+int Print::vprintf(const char *format, va_list ap)
+{
+  return vdprintf((int)this, format, ap);
+}
+
+int Print::vprintf(const __FlashStringHelper *format, va_list ap)
+{
+  return vdprintf((int)this, (const char *)format, ap);
 }
 
 // Private Methods /////////////////////////////////////////////////////////////

--- a/api/Print.h
+++ b/api/Print.h
@@ -21,6 +21,7 @@
 
 #include <inttypes.h>
 #include <stdio.h> // for size_t
+#include <stdarg.h> // for printf
 
 #include "String.h"
 #include "Printable.h"
@@ -72,6 +73,7 @@ class Print
     size_t print(unsigned long, int = DEC);
     size_t print(long long, int = DEC);
     size_t print(unsigned long long, int = DEC);
+    size_t print(float, int = 2);
     size_t print(double, int = 2);
     size_t print(const Printable&);
 
@@ -86,9 +88,15 @@ class Print
     size_t println(unsigned long, int = DEC);
     size_t println(long long, int = DEC);
     size_t println(unsigned long long, int = DEC);
+    size_t println(float, int = 2);
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
+
+    int printf(const char *format, ...);
+    int printf(const __FlashStringHelper *format, ...);
+    int vprintf(const __FlashStringHelper *format, va_list ap);
+    int vprintf(const char *format, va_list ap);
 
     virtual void flush() { /* Empty implementation for backward compatibility */ }
 };


### PR DESCRIPTION
## Summary

Enhance `Print` with:
- `print(float, int digits)`
- `println(float, int digits)`
- `printf(...)`
- `vprintf(...)`

## Why

This improves API completeness and usability:
- `float` gets explicit overloads, matching existing `double` support
- `printf`/`vprintf` provide familiar formatted output on top of the `Print` interface

## Compatibility

This change is additive and backward-compatible:
- existing `Print` users are unaffected
- no existing signatures are changed
- new functionality becomes available to all `Print`-derived classes