### PR TITLE
fix: remove global SPIClass typedef from HardwareSPI API

### DIFF
--- a/api/HardwareSPI.h
+++ b/api/HardwareSPI.h
@@ -139,7 +139,4 @@ class HardwareSPI
     virtual void end() = 0;
 };
 
-// Alias SPIClass to HardwareSPI since it's already the defacto standard for SPI class name
-typedef HardwareSPI SPIClass;
-
 }


### PR DESCRIPTION
## Summary

Remove the global `SPIClass` typedef alias from `HardwareSPI.h`.

## Why

`HardwareSPI` is already the SPI type exposed by ArduinoCore-API.

Some cores, such as STM32, already define their own `SPIClass` type or naming conventions at core level. Providing a global `SPIClass` alias in the shared API can therefore:
- create redefinition or naming conflicts,
- blur the boundary between the generic API type and core-specific SPI implementations,
- force a naming choice that should remain under core control.

Removing the alias keeps the generic API explicit and lets each core decide how its concrete SPI class should be named.

## Compatibility

This change may affect code that depends on `SPIClass` being provided directly by ArduinoCore-API.

Cores and libraries using `HardwareSPI` directly are unaffected.