### PR TITLE
feat: add missing PROGMEM variants in ArduinoCore-API

### DIFF
--- a/api/deprecated-avr-comp/avr/pgmspace.h
+++ b/api/deprecated-avr-comp/avr/pgmspace.h
@@ -100,6 +100,11 @@ typedef const void* uint_farptr_t;
 
 #define sprintf_P(s, f, ...) sprintf((s), (f), __VA_ARGS__)
 #define snprintf_P(s, f, ...) snprintf((s), (f), __VA_ARGS__)
+#define vfprintf_P(fp, s, ...) vfprintf((fp), (s), __VA_ARGS__)
+#define printf_P(...) printf(__VA_ARGS__)
+#define vsprintf_P(s, ...) vsprintf((s), __VA_ARGS__)
+#define vsnprintf_P(s, n, ...) vsnprintf((s), (n), __VA_ARGS__)
+#define fprintf_P(fp, ...) fprintf((fp), __VA_ARGS__)
 
 #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))


### PR DESCRIPTION
## Summary

Add missing `PROGMEM` compatibility macros in `api/deprecated-avr-comp/avr/pgmspace.h`.

## Why

Some AVR-targeted libraries and legacy code use `printf_P`, `fprintf_P`, `vsprintf_P`, or `vsnprintf_P` from `pgmspace.h`.

Providing these missing aliases improves compatibility in non-AVR environments using the ArduinoCore-API AVR compatibility layer, and reduces the need for local workarounds in portable libraries.

## Compatibility

This is an additive compatibility change only:
- existing behavior is unchanged,
- no current API is removed or modified,
- only missing compatibility aliases are introduced.