### PR TITLE
Migrate Stream search internals from char to uint8_t

### DIFF
--- a/api/Stream.cpp
+++ b/api/Stream.cpp
@@ -83,6 +83,16 @@ int Stream::peekNextDigit(LookaheadMode lookahead, bool detectDecimal)
   }
 }
 
+// strlen() for uint8_t*
+size_t strlen_uint8(const uint8_t* str) {
+    if (str == nullptr) return 0; // return 0 for null pointer
+    const uint8_t* p = str;
+    while (*p != 0x00) {
+        p++;
+    }
+    return static_cast<size_t>(p - str);
+}
+
 // Public Methods
 //////////////////////////////////////////////////////////////
 

--- a/api/Stream.cpp
+++ b/api/Stream.cpp
@@ -280,7 +280,7 @@ int Stream::findMulti( struct Stream::MultiTarget *targets, int tCount) {
 
     for (struct MultiTarget *t = targets; t < targets+tCount; ++t) {
       // the simple case is if we match, deal with that first.
-      if ((char)c == t->str[t->index]) {
+      if (c == t->str[t->index]) {
         if (++t->index == t->len)
           return t - targets;
         else
@@ -298,7 +298,7 @@ int Stream::findMulti( struct Stream::MultiTarget *targets, int tCount) {
       do {
         --t->index;
         // first check if current char works against the new current index
-        if ((char)c != t->str[t->index])
+        if (c != t->str[t->index])
           continue;
 
         // if it's the only char then we're good, nothing more to check

--- a/api/Stream.cpp
+++ b/api/Stream.cpp
@@ -102,28 +102,28 @@ void Stream::setTimeout(unsigned long timeout)  // sets the maximum number of mi
 }
 
  // find returns true if the target string is found
-bool  Stream::find(const char *target)
+bool  Stream::find(const uint8_t *target)
 {
-  return findUntil(target, strlen(target), NULL, 0);
+  return findUntil(target, strlen_uint8(target), NULL, 0);
 }
 
 // reads data from the stream until the target string of given length is found
 // returns true if target string is found, false if timed out
-bool Stream::find(const char *target, size_t length)
+bool Stream::find(const uint8_t *target, size_t length)
 {
   return findUntil(target, length, NULL, 0);
 }
 
 // as find but search ends if the terminator string is found
-bool  Stream::findUntil(const char *target, const char *terminator)
+bool  Stream::findUntil(const uint8_t *target, const uint8_t *terminator)
 {
-  return findUntil(target, strlen(target), terminator, strlen(terminator));
+  return findUntil(target, strlen_uint8(target), terminator, strlen_uint8(terminator));
 }
 
 // reads data from the stream until the target string of the given length is found
 // search terminated if the terminator string is found
 // returns true if target string is found, false if terminated or timed out
-bool Stream::findUntil(const char *target, size_t targetLen, const char *terminator, size_t termLen)
+bool Stream::findUntil(const uint8_t *target, size_t targetLen, const uint8_t *terminator, size_t termLen)
 {
   if (terminator == NULL) {
     MultiTarget t[1] = {{target, targetLen, 0}};

--- a/api/Stream.h
+++ b/api/Stream.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <inttypes.h>
+
 #include "Print.h"
 
 // compatibility macros for testing
@@ -67,22 +68,22 @@ class Stream : public Print
 
   void setTimeout(unsigned long timeout);  // sets maximum milliseconds to wait for stream data, default is 1 second
   unsigned long getTimeout(void) { return _timeout; }
-  
-  bool find(const char *target);   // reads data from the stream until the target string is found
-  bool find(const uint8_t *target) { return find ((const char *)target); }
+
+  bool find(const uint8_t *target);   // reads data from the stream until the target string is found
+  bool find(const char *target) { return find ((const uint8_t *)target); }
   // returns true if target string is found, false if timed out (see setTimeout)
 
-  bool find(const char *target, size_t length);   // reads data from the stream until the target string of given length is found
-  bool find(const uint8_t *target, size_t length) { return find ((const char *)target, length); }
+  bool find(const uint8_t *target, size_t length);   // reads data from the stream until the target string of given length is found
+  bool find(const char *target, size_t length) { return find ((const uint8_t *)target, length); }
   // returns true if target string is found, false if timed out
 
-  bool find(char target) { return find (&target, 1); }
+  bool find(uint8_t target) { return find (&target, 1); }
 
-  bool findUntil(const char *target, const char *terminator);   // as find but search ends if the terminator string is found
-  bool findUntil(const uint8_t *target, const char *terminator) { return findUntil((const char *)target, terminator); }
+  bool findUntil(const uint8_t *target, const uint8_t *terminator);   // as find but search ends if the terminator string is found
+  bool findUntil(const char *target, const char *terminator) { return findUntil((const uint8_t *)target, (const uint8_t *)terminator); }
 
-  bool findUntil(const char *target, size_t targetLen, const char *terminate, size_t termLen);   // as above but search ends if the terminate string is found
-  bool findUntil(const uint8_t *target, size_t targetLen, const char *terminate, size_t termLen) {return findUntil((const char *)target, targetLen, terminate, termLen); }
+  bool findUntil(const uint8_t *target, size_t targetLen, const uint8_t *terminator, size_t termLen);
+  bool findUntil(const char *target, size_t targetLen, const char *terminator, size_t termLen) { return findUntil((const uint8_t*)target, targetLen, (const uint8_t*)terminator, termLen); }
 
   long parseInt(LookaheadMode lookahead = SKIP_ALL, char ignore = NO_IGNORE_CHAR);
   // returns the first valid (long) integer value from the current position.
@@ -116,7 +117,7 @@ class Stream : public Print
   // the public API simple, these overload remains protected.
 
   struct MultiTarget {
-    const char *str;  // string you're searching for
+    const uint8_t *str;  // string you're searching for
     size_t len;       // length of string you're searching for
     size_t index;     // index used by the search routine.
   };


### PR DESCRIPTION
## Overview

This PR will fix the issue #119.

With the current code, `Stream::find()` cannot find values above 0x7f because it treats the target string as `char`, meaning that many UTF-8 encoded characters cannot be matched either.
This PR fixes the issue by changing the target string type from `char` to `uint8_t`.

## Verification on an actual device

### Find single-byte number above 0x7f

When 0x80 is sent via the serial monitor, the sketch below returns "Not found.” with current code while it returns “Found!” this PR's fixed code.

``` ino
#include <Arduino.h>

const uint8_t TARGET_NUM = 0x80; // above 0x7f

void setup() { Serial.begin(115200); }

void loop() {
  if (Serial.available()) {
    if (Serial.find(TARGET_NUM)) {
      Serial.println("Found!");
    } else {
      Serial.println("Not found.");
    }
  }
}
```

### Find multi-byte UTF-8 character

With the current code, the sketch below fails to build with the error `no instance of overloaded function "Serial_::find" matches the argument list`. With the fixed code, it builds and works as expected.

``` ino
#include <Arduino.h>

const uint8_t TARGET_STR[] = "やあ😀";
// E3 82 84 + E3 81 82 + F0 9F 98 80

void setup() { Serial.begin(115200); }

void loop() {
  if (Serial.available()) {
    if (Serial.find(TARGET_STR)) {
      Serial.println("Found!");
    } else {
      Serial.println("Not found.");
    }
  }
}
```