### PR TITLE
Extend bit manipulation for 64-bit values

### DIFF
--- a/api/Common.h
+++ b/api/Common.h
@@ -82,14 +82,14 @@ typedef void (*voidFuncPtrParam)(void*);
 #define lowByte(w) ((uint8_t) ((w) & 0xff))
 #define highByte(w) ((uint8_t) ((w) >> 8))
 
-#define bitRead(value, bit) (((value) >> (bit)) & 0x01)
-#define bitSet(value, bit) ((value) |= (1UL << (bit)))
-#define bitClear(value, bit) ((value) &= ~(1UL << (bit)))
-#define bitToggle(value, bit) ((value) ^= (1UL << (bit)))
+#define bitRead(value, bit) (((value) >> (bit)) & 0x01ULL)
+#define bitSet(value, bit) ((value) |= (1ULL << (bit)))
+#define bitClear(value, bit) ((value) &= ~(1ULL << (bit)))
+#define bitToggle(value, bit) ((value) ^= (1ULL << (bit)))
 #define bitWrite(value, bit, bitvalue) ((bitvalue) ? bitSet((value), (bit)) : bitClear((value), (bit)))
 
 #ifndef bit
-#define bit(b) (1UL << (b))
+#define bit(b) (1ULL << (b))
 #endif
 
 /* TODO: request for removal */


### PR DESCRIPTION
This PR will close the issue #261.

In my view, simply changing this from `UL` to `ULL` (as @JDat said in the issue) should suffice and would maintain compatibility with existing code using this API.
But I am not entirely certain, so I would appreciate your feedback and discussion.