### PR TITLE
Add Serial.print(foo, HEX_LEADINGZERO)

### DIFF
--- a/api/Print.cpp
+++ b/api/Print.cpp
@@ -238,24 +238,30 @@ size_t Print::println(const Printable& x)
 
 // Private Methods /////////////////////////////////////////////////////////////
 
-size_t Print::printNumber(unsigned long n, uint8_t base)
+size_t Print::printNumber(unsigned long n, int8_t base)
 {
   char buf[8 * sizeof(long) + 1]; // Assumes 8-bit chars plus zero byte.
   char *str = &buf[sizeof(buf) - 1];
-
   *str = '\0';
+  size_t leadingZero = 0;
 
-  // prevent crash if called with base == 1
-  if (base < 2) base = 10;
+  // insert leading zero for hex values less than 0x10
+  if (base == -16 && n < 16) {
+    write('0');
+    leadingZero = 1;
+  }
+  // or prevent crash if called with base == 1
+  else if (base < 2) base = 10;
 
   do {
-    char c = n % base;
-    n /= base;
+    // use abs() to support HEX_LEADINGZERO, which is negative
+    char c = n % abs(base);
+    n /= abs(base);
 
     *--str = c < 10 ? c + '0' : c + 'A' - 10;
   } while(n);
 
-  return write(str);
+  return write(str) + leadingZero;
 }
 
 // REFERENCE IMPLEMENTATION FOR ULL
@@ -281,28 +287,39 @@ size_t Print::printNumber(unsigned long n, uint8_t base)
 // }
 
 // FAST IMPLEMENTATION FOR ULL
-size_t Print::printULLNumber(unsigned long long n64, uint8_t base)
+size_t Print::printULLNumber(unsigned long long n64, int8_t base)
 {
   // if limited to base 10 and 16 the bufsize can be 20
   char buf[64];
   uint8_t i = 0;
   uint8_t innerLoops = 0;
+  size_t leadingZero = 0;
 
   // Special case workaround https://github.com/arduino/ArduinoCore-API/issues/178
   if (n64 == 0) {
+    if (base == -16) {
+      write('0');
+      write('0');
+      return 2;
+    }
     write('0');
     return 1;
   }
 
-  // prevent crash if called with base == 1
-  if (base < 2) base = 10;
+  // insert leading zero for hex values less than 0x10
+  if (base == -16 && n64 < 16) {
+    write('0');
+    leadingZero = 1;
+  }
+  // or prevent crash if called with base == 1
+  else if (base < 2) base = 10;
 
   // process chunks that fit in "16 bit math".
-  uint16_t top = 0xFFFF / base;
+  uint16_t top = 0xFFFF / abs(base);
   uint16_t th16 = 1;
   while (th16 < top)
   {
-    th16 *= base;
+    th16 *= abs(base);
     innerLoops++;
   }
 
@@ -316,8 +333,8 @@ size_t Print::printULLNumber(unsigned long long n64, uint8_t base)
     // 16 bit math loop to do remainder. (note buffer is filled reverse)
     for (uint8_t j=0; j < innerLoops; j++)
     {
-      uint16_t qq = r/base;
-      buf[i++] = r - qq*base;
+      uint16_t qq = r/abs(base);
+      buf[i++] = r - qq*abs(base);
       r = qq;
     }
   }
@@ -325,8 +342,8 @@ size_t Print::printULLNumber(unsigned long long n64, uint8_t base)
   uint16_t n16 = n64;
   while (n16 > 0)
   {
-    uint16_t qq = n16/base;
-    buf[i++] = n16 - qq*base;
+    uint16_t qq = n16/abs(base);
+    buf[i++] = n16 - qq*abs(base);
     n16 = qq;
   }
 
@@ -336,7 +353,7 @@ size_t Print::printULLNumber(unsigned long long n64, uint8_t base)
     '0' + buf[i - 1] :
     'A' + buf[i - 1] - 10));
 
-  return bytes;
+  return bytes + leadingZero;
 }
 
 size_t Print::printFloat(double number, int digits)

--- a/api/Print.h
+++ b/api/Print.h
@@ -27,6 +27,7 @@
 
 #define DEC 10
 #define HEX 16
+#define HEX_LEADINGZERO -16
 #define OCT 8
 #define BIN 2
 
@@ -36,8 +37,8 @@ class Print
 {
   private:
     int write_error;
-    size_t printNumber(unsigned long, uint8_t);
-    size_t printULLNumber(unsigned long long, uint8_t);
+    size_t printNumber(unsigned long, int8_t);
+    size_t printULLNumber(unsigned long long, int8_t);
     size_t printFloat(double, int);
   protected:
     void setWriteError(int err = 1) { write_error = err; }

--- a/test/src/Print/test_print.cpp
+++ b/test/src/Print/test_print.cpp
@@ -119,17 +119,20 @@ TEST_CASE ("Print::print(unsigned long long, int = DEC|HEX|OCT|BIN)", "[Print-pr
 
     WHEN("DEC") { mock.print(val, DEC); REQUIRE(mock._str  == "0"); }
     WHEN("HEX") { mock.print(val, HEX); REQUIRE(mock._str  == "0"); }
+    WHEN("HEX_LEADINGZERO") { mock.print(val, HEX_LEADINGZERO); REQUIRE(mock._str  == "00"); }
     WHEN("OCT") { mock.print(val, OCT); REQUIRE(mock._str  == "0"); }
     WHEN("BIN") { mock.print(val, BIN); REQUIRE(mock._str  == "0"); }
   }
+
   GIVEN("a non-zero value ...")
   {
-    unsigned long long const val = 17;
+    unsigned long long const val = 15;
 
-    WHEN("DEC") { mock.print(val, DEC); REQUIRE(mock._str  == "17"); }
-    WHEN("HEX") { mock.print(val, HEX); REQUIRE(mock._str  == "11"); }
-    WHEN("OCT") { mock.print(val, OCT); REQUIRE(mock._str  == "21"); }
-    WHEN("BIN") { mock.print(val, BIN); REQUIRE(mock._str  == "10001"); }
+    WHEN("DEC") { mock.print(val, DEC); REQUIRE(mock._str  == "15"); }
+    WHEN("HEX") { mock.print(val, HEX); REQUIRE(mock._str  == "F"); }
+    WHEN("HEX_LEADINGZERO") { mock.print(val, HEX_LEADINGZERO); REQUIRE(mock._str  == "0F"); }
+    WHEN("OCT") { mock.print(val, OCT); REQUIRE(mock._str  == "17"); }
+    WHEN("BIN") { mock.print(val, BIN); REQUIRE(mock._str  == "1111"); }
   }
 }
 


### PR DESCRIPTION
This PR might close the issue #40.
I have submitted PR #280 later as a more radical alternative.
I hope either one of them gets merged.

## Overview

With the current implementation, `Serial.print(1, HEX)` outputs `1`.
However, by convention, it should output `01`.
This was also discussed in the issue.

In this PR, I added a new option `HEX_LEADINGZERO` to output `01`.
I have kept `HEX` as is to maintain backward compatibility.

## Implementation details

I added `#define HEX_LEADINGZERO -16` to distinguish it from the conventional `#define HEX 16`.

When using the number `16` in division, `abs()` is used to absorb the difference in sign.

---

That being said, `HEX_LEADINGZERO` might be a bit too long.
I would appreciate any alternative naming suggestions if you have better ideas.